### PR TITLE
data hygiene updates

### DIFF
--- a/data-hygiene/deploy/App.txt
+++ b/data-hygiene/deploy/App.txt
@@ -3,12 +3,12 @@
 <head>
     <title>Data Hygiene App</title>
     <!--  (c) 2016 CA Technologies.  All Rights Reserved. -->
-    <!--  Build Date: Wed Jul 12 2017 14:37:29 GMT-0700 (PDT) -->
+    <!--  Build Date: Tue Jul 18 2017 22:50:35 GMT-0700 (PDT) -->
     
     <script type="text/javascript">
-        var APP_BUILD_DATE = "Wed Jul 12 2017 14:37:29 GMT-0700 (PDT)";
+        var APP_BUILD_DATE = "Tue Jul 18 2017 22:50:35 GMT-0700 (PDT)";
         var BUILDER = "rajan08";
-        var CHECKSUM = 223237464448;
+        var CHECKSUM = 477809296306;
     </script>
     
     <script type="text/javascript" src="/apps/2.1/sdk.js"></script>
@@ -16,6 +16,247 @@
     <script type="text/javascript">
         Rally.onReady(function() {
              
+/* FileSaver.js
+ *  A saveAs() FileSaver implementation.
+ *  2014-05-27
+ *
+ *  By Eli Grey, http://eligrey.com
+ *  License: X11/MIT
+ *    See https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+ */
+
+/*global self */
+/*jslint bitwise: true, indent: 4, laxbreak: true, laxcomma: true, smarttabs: true, plusplus: true */
+
+/*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
+
+var saveAs = saveAs
+  // IE 10+ (native saveAs)
+  || (typeof navigator !== "undefined" &&
+      navigator.msSaveOrOpenBlob && navigator.msSaveOrOpenBlob.bind(navigator))
+  // Everyone else
+  || (function(view) {
+    "use strict";
+    // IE <10 is explicitly unsupported
+    if (typeof navigator !== "undefined" &&
+        /MSIE [1-9]\./.test(navigator.userAgent)) {
+        return;
+    }
+    var
+          doc = view.document
+          // only get URL when necessary in case Blob.js hasn't overridden it yet
+        , get_URL = function() {
+            return view.URL || view.webkitURL || view;
+        }
+        , save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a")
+        , can_use_save_link = !view.externalHost && "download" in save_link
+        , click = function(node) {
+            var event = doc.createEvent("MouseEvents");
+            event.initMouseEvent(
+                "click", true, false, view, 0, 0, 0, 0, 0
+                , false, false, false, false, 0, null
+            );
+            node.dispatchEvent(event);
+        }
+        , webkit_req_fs = view.webkitRequestFileSystem
+        , req_fs = view.requestFileSystem || webkit_req_fs || view.mozRequestFileSystem
+        , throw_outside = function(ex) {
+            (view.setImmediate || view.setTimeout)(function() {
+                throw ex;
+            }, 0);
+        }
+        , force_saveable_type = "application/octet-stream"
+        , fs_min_size = 0
+        , deletion_queue = []
+        , process_deletion_queue = function() {
+            var i = deletion_queue.length;
+            while (i--) {
+                var file = deletion_queue[i];
+                if (typeof file === "string") { // file is an object URL
+                    get_URL().revokeObjectURL(file);
+                } else { // file is a File
+                    file.remove();
+                }
+            }
+            deletion_queue.length = 0; // clear queue
+        }
+        , dispatch = function(filesaver, event_types, event) {
+            event_types = [].concat(event_types);
+            var i = event_types.length;
+            while (i--) {
+                var listener = filesaver["on" + event_types[i]];
+                if (typeof listener === "function") {
+                    try {
+                        listener.call(filesaver, event || filesaver);
+                    } catch (ex) {
+                        throw_outside(ex);
+                    }
+                }
+            }
+        }
+        , FileSaver = function(blob, name) {
+            // First try a.download, then web filesystem, then object URLs
+            var
+                  filesaver = this
+                , type = blob.type
+                , blob_changed = false
+                , object_url
+                , target_view
+                , get_object_url = function() {
+                    var object_url = get_URL().createObjectURL(blob);
+                    deletion_queue.push(object_url);
+                    return object_url;
+                }
+                , dispatch_all = function() {
+                    dispatch(filesaver, "writestart progress write writeend".split(" "));
+                }
+                // on any filesys errors revert to saving with object URLs
+                , fs_error = function() {
+                    // don't create more object URLs than needed
+                    if (blob_changed || !object_url) {
+                        object_url = get_object_url(blob);
+                    }
+                    if (target_view) {
+                        target_view.location.href = object_url;
+                    } else {
+                        window.open(object_url, "_blank");
+                    }
+                    filesaver.readyState = filesaver.DONE;
+                    dispatch_all();
+                }
+                , abortable = function(func) {
+                    return function() {
+                        if (filesaver.readyState !== filesaver.DONE) {
+                            return func.apply(this, arguments);
+                        }
+                    };
+                }
+                , create_if_not_found = {create: true, exclusive: false}
+                , slice
+            ;
+            filesaver.readyState = filesaver.INIT;
+            if (!name) {
+                name = "download";
+            }
+            if (can_use_save_link) {
+                object_url = get_object_url(blob);
+                save_link.href = object_url;
+                save_link.download = name;
+                click(save_link);
+                filesaver.readyState = filesaver.DONE;
+                dispatch_all();
+                return;
+            }
+            // Object and web filesystem URLs have a problem saving in Google Chrome when
+            // viewed in a tab, so I force save with application/octet-stream
+            // http://code.google.com/p/chromium/issues/detail?id=91158
+            if (view.chrome && type && type !== force_saveable_type) {
+                slice = blob.slice || blob.webkitSlice;
+                blob = slice.call(blob, 0, blob.size, force_saveable_type);
+                blob_changed = true;
+            }
+            // Since I can't be sure that the guessed media type will trigger a download
+            // in WebKit, I append .download to the filename.
+            // https://bugs.webkit.org/show_bug.cgi?id=65440
+            if (webkit_req_fs && name !== "download") {
+                name += ".download";
+            }
+            if (type === force_saveable_type || webkit_req_fs) {
+                target_view = view;
+            }
+            if (!req_fs) {
+                fs_error();
+                return;
+            }
+            fs_min_size += blob.size;
+            req_fs(view.TEMPORARY, fs_min_size, abortable(function(fs) {
+                fs.root.getDirectory("saved", create_if_not_found, abortable(function(dir) {
+                    var save = function() {
+                        dir.getFile(name, create_if_not_found, abortable(function(file) {
+                            file.createWriter(abortable(function(writer) {
+                                writer.onwriteend = function(event) {
+                                    target_view.location.href = file.toURL();
+                                    deletion_queue.push(file);
+                                    filesaver.readyState = filesaver.DONE;
+                                    dispatch(filesaver, "writeend", event);
+                                };
+                                writer.onerror = function() {
+                                    var error = writer.error;
+                                    if (error.code !== error.ABORT_ERR) {
+                                        fs_error();
+                                    }
+                                };
+                                "writestart progress write abort".split(" ").forEach(function(event) {
+                                    writer["on" + event] = filesaver["on" + event];
+                                });
+                                writer.write(blob);
+                                filesaver.abort = function() {
+                                    writer.abort();
+                                    filesaver.readyState = filesaver.DONE;
+                                };
+                                filesaver.readyState = filesaver.WRITING;
+                            }), fs_error);
+                        }), fs_error);
+                    };
+                    dir.getFile(name, {create: false}, abortable(function(file) {
+                        // delete file if it already exists
+                        file.remove();
+                        save();
+                    }), abortable(function(ex) {
+                        if (ex.code === ex.NOT_FOUND_ERR) {
+                            save();
+                        } else {
+                            fs_error();
+                        }
+                    }));
+                }), fs_error);
+            }), fs_error);
+        }
+        , FS_proto = FileSaver.prototype
+        , saveAs = function(blob, name) {
+            return new FileSaver(blob, name);
+        }
+    ;
+    FS_proto.abort = function() {
+        var filesaver = this;
+        filesaver.readyState = filesaver.DONE;
+        dispatch(filesaver, "abort");
+    };
+    FS_proto.readyState = FS_proto.INIT = 0;
+    FS_proto.WRITING = 1;
+    FS_proto.DONE = 2;
+
+    FS_proto.error =
+    FS_proto.onwritestart =
+    FS_proto.onprogress =
+    FS_proto.onwrite =
+    FS_proto.onabort =
+    FS_proto.onerror =
+    FS_proto.onwriteend =
+        null;
+
+    view.addEventListener("unload", process_deletion_queue, false);
+    saveAs.unload = function() {
+        process_deletion_queue();
+        view.removeEventListener("unload", process_deletion_queue, false);
+    };
+    return saveAs;
+}(
+       typeof self !== "undefined" && self
+    || typeof window !== "undefined" && window
+    || this.content
+));
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window
+
+if (typeof module !== "undefined" && module !== null) {
+  module.exports = saveAs;
+} else if ((typeof define !== "undefined" && define !== null) && (define.amd != null)) {
+  define([], function() {
+    return saveAs;
+  });
+}
 /**
  * A link that pops up a version dialog box
  */
@@ -595,6 +836,1116 @@ Ext.define('Rally.technicalservices.FileUtilities', {
     }
 
 });
+Ext.define('Rally.technicalservices.FileUtilities', {
+    singleton: true,
+    logger: new Rally.technicalservices.Logger(),
+    saveCSVToFile:function(csv,file_name,type_object){
+            if (type_object == undefined){
+                type_object = {type:'text/csv;charset=utf-8'};
+            }
+            var blob = new Blob([csv],type_object);
+            saveAs(blob,file_name);
+    },
+    saveTextAsFile: function(textToWrite, fileName) {
+        var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
+        var fileNameToSaveAs = fileName;
+
+        var downloadLink = document.createElement("a");
+        downloadLink.download = fileNameToSaveAs;
+        downloadLink.innerHTML = "Download File";
+        if (window.webkitURL != null)
+        {
+            // Chrome allows the link to be clicked
+            // without actually adding it to the DOM.
+            downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
+        }
+        else
+        {
+            // Firefox requires the link to be added to the DOM
+            // before it can be clicked.
+            downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
+            downloadLink.onclick = destroyClickedElement;
+            downloadLink.style.display = "none";
+            document.body.appendChild(downloadLink);
+        }
+        downloadLink.click();
+    },
+    destroyClickedElement: function(event)
+    {
+        document.body.removeChild(event.target);
+    },
+    convertDataArrayToCSVText: function(data_array, requestedFieldHash){
+       
+        var text = '';
+        Ext.each(Object.keys(requestedFieldHash), function(key){
+            text += requestedFieldHash[key] + ',';
+        });
+        text = text.replace(/,$/,'\n');
+        
+        Ext.each(data_array, function(d){
+            Ext.each(Object.keys(requestedFieldHash), function(key){
+                if (d[key]){
+                    if (typeof d[key] === 'object'){
+                        if (d[key].FormattedID) {
+                            text += Ext.String.format("\"{0}\",",d[key].FormattedID ); 
+                        } else if (d[key].Name) {
+                            text += Ext.String.format("\"{0}\",",d[key].Name );                    
+                        } else if (!isNaN(Date.parse(d[key]))){
+                            text += Ext.String.format("\"{0}\",",Rally.util.DateTime.formatWithDefaultDateTime(d[key]));
+                        }else {
+                            text += Ext.String.format("\"{0}\",",d[key].toString());
+                        }
+                    } else {
+                        text += Ext.String.format("\"{0}\",",d[key] );                    
+                    }
+                } else {
+                    text += ',';
+                }
+            },this);
+            text = text.replace(/,$/,'\n');
+        },this);
+        return text;
+    },
+    _getCSVFromWsapiBackedGrid: function(grid) {
+        var deferred = Ext.create('Deft.Deferred');
+        var store = Ext.create('Rally.data.wsapi.Store',{
+            fetch: grid.getStore().config.fetch,
+            filters: grid.getStore().config.filters,
+            model: grid.getStore().config.model,
+            limit:Infinity,
+            pageSize: Infinity
+
+        });
+        
+        var columns = grid.columns;
+        var headers = this._getHeadersFromGrid(grid);
+        var column_names = this._getColumnNamesFromGrid(grid);
+        
+        var record_count = grid.getStore().getTotalCount(),
+            page_size = grid.getStore().pageSize,
+            pages = Math.ceil(record_count/page_size),
+            promises = [];
+
+        for (var page = 1; page <= pages; page ++ ) {
+            promises.push(this.loadStorePage(grid, store, columns, page, pages));
+        }
+        Deft.Promise.all(promises).then({
+            success: function(csvs){
+                var csv = [];
+                csv.push('"' + headers.join('","') + '"');
+                _.each(csvs, function(c){
+                    _.each(c, function(line){
+                        csv.push(line);
+                    });
+                });
+                csv = csv.join('\r\n');
+                deferred.resolve(csv);
+                Rally.getApp().setLoading(false);
+            }
+        });
+        return deferred.promise;
+    },
+
+    // custom grid assumes there store is fully loaded
+    _getCSVFromCustomBackedGridWithPaging: function(grid) {
+        var deferred = Ext.create('Deft.Deferred');
+
+
+        var store = Ext.create('Rally.data.custom.Store',{
+            model: grid.getStore().config.model,
+            filters: grid.getStore().config.filters,
+            limit:Infinity,
+            pageSize: Infinity
+        });
+
+        var columns = grid.columns;
+        var headers = this._getHeadersFromGrid(grid);
+        var column_names = this._getColumnNamesFromGrid(grid);
+        
+        var record_count = grid.getStore().getTotalCount(),
+            page_size = grid.getStore().pageSize,
+            pages = Math.ceil(record_count/page_size),
+            promises = [];
+
+        // for (var page = 1; page <= pages; page ++ ) {
+        //     promises.push(this.loadStorePage(grid, store, columns, page, pages));
+        // }
+
+        promises.push(this.loadStorePage(grid, store, columns, page, pages));
+
+        Deft.Promise.all(promises).then({
+            success: function(csvs){
+                var csv = [];
+                csv.push('"' + headers.join('","') + '"');
+                _.each(csvs, function(c){
+                    _.each(c, function(line){
+                        csv.push(line);
+                    });
+                });
+                csv = csv.join('\r\n');
+                deferred.resolve(csv);
+                Rally.getApp().setLoading(false);
+            }
+        });
+        return deferred.promise;
+
+        // var headers = this._getHeadersFromGrid(grid);
+        
+        // var columns = grid.columns;
+        // var column_names = this._getColumnNamesFromGrid(grid);
+
+       
+        // var csv = [];
+        // csv.push('"' + headers.join('","') + '"');
+
+        // var number_of_records = store.getTotalCount();
+        
+        // this.logger.log("Number of records to export:", number_of_records);
+        
+        // for (var i = 0; i < number_of_records; i++) {
+        //     var record = store.getAt(i);
+        //     if ( ! record ) {
+        //         this.logger.log("Number or lines in CSV:", csv.length);
+        //         return csv.join('\r\n');            }
+        //     csv.push( this._getCSVFromRecord(record, grid, store) );
+        // }
+        
+        // this.logger.log("Number or lines in CSV:", csv.length);
+        // return csv.join('\r\n');
+    },
+
+    
+    // custom grid assumes there store is fully loaded
+    _getCSVFromCustomBackedGrid: function(grid) {
+    var deferred = Ext.create('Deft.Deferred');
+            var me = this;
+            
+            Rally.getApp().setLoading("Assembling data for export...");
+            
+            var headers = this._getHeadersFromGrid(grid);
+            var store = Ext.clone( grid.getStore() );
+            var columns = grid.columns;
+            var column_names = this._getColumnNamesFromGrid(grid);
+            
+            var record_count = grid.getStore().getTotalCount();
+            var original_page_size = grid.getStore().pageSize;
+            
+            var page_size = 20000;
+            var number_of_pages = Math.ceil(record_count/page_size);
+            store.pageSize = page_size;
+            
+            var pages = [],
+                promises = [];
+
+            for (var page = 1; page <= number_of_pages; page ++ ) {
+                pages.push(page);
+            }
+            
+            Ext.Array.each(pages, function(page) {
+                promises.push(function() { 
+                    return me._loadStorePage(grid, store, columns, page, pages.length )
+                });
+            });
+            
+            Deft.Chain.sequence(promises).then({
+                success: function(csvs){
+
+                    // set page back to last view
+                    store.pageSize = original_page_size;
+                    store.loadPage(1);
+                    
+                    var csv = [];
+                    csv.push('"' + headers.join('","') + '"');
+                    _.each(csvs, function(c){
+                        _.each(c, function(line){
+                            csv.push(line);
+                        });
+                    });
+                    csv = csv.join('\r\n');
+                    deferred.resolve(csv);
+                    Rally.getApp().setLoading(false);
+                }
+            });
+            
+            return deferred.promise;
+    },
+    
+
+
+    _loadStorePage: function(grid, store, columns, page, total_pages){
+        var deferred = Ext.create('Deft.Deferred');
+
+        store.loadPage(page, {
+            callback: function (records) {
+                var csv = [];
+                for (var i = 0; i < records.length; i++) {
+                    // if(i==0){
+                    //     Rally.getApp().setLoading("Loading page "+page+ " of "+total_pages);
+                    // }
+                    var record = records[i];
+                    csv.push( this._getCSVFromRecord(record, grid, store) );
+                }
+                deferred.resolve(csv);
+            },
+            scope: this
+        });
+        this.logger.log("_loadStorePage", page, " of ", total_pages);
+        return deferred.promise;
+    },
+
+
+    _getHeadersFromGrid: function(grid) {
+        var headers = [];        
+        var columns = grid.columns;
+
+        Ext.Array.each(columns,function(column){
+            if ( column.dataIndex || column.renderer ) {
+                if ( column.csvText ) {
+                    headers.push(column.csvText.replace('&nbsp;',' '));
+                } else if ( column.text )  {
+                    headers.push(column.text.replace('&nbsp;',' '));
+                }
+            }
+        });
+        
+        return headers;
+    },
+    
+    _getColumnNamesFromGrid: function(grid) {
+        var names = [];
+        var columns = grid.columns;
+
+        Ext.Array.each(columns,function(column){
+            if ( column.dataIndex || column.renderer ) {
+                names.push(column.dataIndex);
+            }
+        });
+        
+        return names;
+    },
+    /*
+     * will render using your grid renderer.  If you want it to ignore the grid renderer, 
+     * have the column set _csvIgnoreRender: true
+     */
+    getCSVFromGrid:function(app, grid){
+        this.logger.log("Exporting grid with store type:", Ext.getClassName(grid.getStore()));
+        
+        if ( Ext.getClassName(grid.getStore()) != "Rally.data.custom.Store" ) {
+            return this._getCSVFromWsapiBackedGrid(grid);
+        }
+        
+        return this._getCSVFromCustomBackedGrid(grid);
+    },
+
+    loadStorePage: function(grid, store, columns, page, total_pages){
+        console.log('Inside loadStorePage');
+        var deferred = Ext.create('Deft.Deferred');
+        this.logger.log('loadStorePage',page, total_pages);
+
+        store.loadPage(page, {
+            callback: function (records, operation, success) {
+                //console.log(' page records length',records.length,'success',success);
+                var csv = [];
+                Rally.getApp().setLoading(Ext.String.format('Page {0} of {1} loaded',page, total_pages));
+                for (var i = 0; i < records.length; i++) {
+                    var record = records[i];
+                    csv.push( this._getCSVFromRecord(record, grid, store) );
+                }
+                deferred.resolve(csv);
+            },
+            scope: this
+        });
+        return deferred;
+    },
+    
+    _getCSVFromRecord: function(record, grid, store) {
+        var mock_meta_data = {
+            align: "right",
+            classes: [],
+            cellIndex: 9,
+            column: null,
+            columnIndex: 9,
+            innerCls: undefined,
+            recordIndex: 5,
+            rowIndex: 5,
+            style: "",
+            tdAttr: "",
+            tdCls: "x-grid-cell x-grid-td x-grid-cell-headerId-gridcolumn-1029 x-grid-cell-last x-unselectable",
+            unselectableAttr: "unselectable='on'"
+        };
+        
+        var node_values = [];
+        var columns = grid.columns;
+        //console.log('inside _getCSVFromRecord');
+        Ext.Array.each(columns, function (column) {
+            if (column.xtype != 'rallyrowactioncolumn') {
+                if (column.dataIndex) {
+                    var column_name = column.dataIndex;
+                    
+                    var display_value = record.get(column_name);
+
+                    if (!column._csvIgnoreRender && column.renderer) {
+                        if (column.exportRenderer) {
+                            display_value = column.exportRenderer(display_value, mock_meta_data, record, 0, 0, store, grid.getView());
+                        } else {
+                            display_value = column.renderer(display_value, mock_meta_data, record, 0, 0, store, grid.getView());
+                        }
+                    }
+                    //node_values.push(display_value ? display_value.replace(/"/g, '""') : display_value);
+                    node_values.push(display_value);
+                } else {
+                    var display_value = null;
+                    if (!column._csvIgnoreRender && column.renderer) {
+                        if (column.exportRenderer) {
+                            display_value = column.exportRenderer(display_value, mock_meta_data, record, record, 0, 0, store, grid.getView());
+                        } else {
+                            display_value = column.renderer(display_value, mock_meta_data, record, record, 0, 0, store, grid.getView());
+                        }
+                        // node_values.push(display_value ? display_value.replace(/"/g, '""') : display_value);
+                        node_values.push(display_value);
+                    }
+                }
+
+            }
+        }, this);
+        console.log('Node values',node_values);
+        return '"' + node_values.join('","') + '"';
+    }
+
+});
+Ext.define('CA.technicalservices.ProjectTreePickerDialog', {
+    extend: 'Rally.ui.dialog.Dialog',
+    alias: 'widget.projecttreepickerdialog',
+
+    minWidth: 400,
+    width: 400,
+    minHeight: 300,
+    height: 300,
+    
+    layout: 'fit',
+    closable: true,
+    draggable: true,
+
+    config: {
+        /**
+         * @cfg {String}
+         * Title to give to the dialog
+         */
+        title: 'Choose Project(s)',
+
+        /**
+         * @cfg {Boolean}
+         * Allow multiple selection or not
+         */
+        multiple: true,
+
+        /**
+         * @cfg {Object}
+         * An {Ext.data.Store} config object used when building the grid
+         * Handy when you need to limit the selection with store filters
+         */
+        storeConfig: {
+            context: {
+                project: null
+            },
+            sorters: [
+                {
+                    property: 'FormattedID',
+                    direction: 'DESC'
+                }
+            ]
+        },
+
+        /**
+         * @cfg {Ext.grid.Column}
+         * List of columns that will be used in the chooser
+         */
+        columns: [
+            'Name'
+        ],
+
+        /**
+         * @cfg {String}
+         * Text to be displayed on the button when selection is complete
+         */
+        selectionButtonText: 'Done',
+
+        /**
+         * @cfg {Object}
+         * The grid configuration to be used when creative the grid of items in the dialog
+         */
+        gridConfig: {},
+
+        /**
+         * @cfg {String}|{String[]}
+         * The ref(s) of items which should be selected when the chooser loads
+         */
+        selectedRecords: undefined,
+
+        /**
+         * @cfg {Array}
+         * The records to select when the chooser loads
+         */
+        initialSelectedRecords: undefined,
+
+        /**
+         * @cfg showRadioButtons {Boolean}
+         */
+        showRadioButtons: true,
+        
+        /**
+         * @cfg showSearchBox {Boolean}
+         * 
+         * [ Experimental.  Search box might not work ]
+         */
+        showSearchBox: false
+    },
+
+    constructor: function(config) {
+        this.mergeConfig(config);
+
+        this.callParent([this.config]);
+    },
+
+    selectionCache: [],
+
+    initComponent: function() {
+        this.callParent(arguments);
+
+        this.addEvents(
+            /**
+             * @event artifactchosen
+             * Fires when user clicks done after choosing an artifact
+             * @param {Rally.ui.dialog.ArtifactChooserDialog} source the dialog
+             * @param {Rally.data.wsapi.Model}| {Rally.data.wsapi.Model[]} selection selected record or an array of selected records if multiple is true
+             */
+            'itemschosen'
+        );
+
+        this.addCls(['chooserDialog', 'chooser-dialog']);
+    },
+
+    destroy: function() {
+        //      this._destroyTooltip();
+        this.callParent(arguments);
+    },
+
+    beforeRender: function() {
+        this.callParent(arguments);
+
+        this.addDocked({
+            xtype: 'toolbar',
+            dock: 'bottom',
+            padding: '0 0 10 0',
+            layout: {
+                type: 'hbox',
+                pack: 'center'
+            },
+            ui: 'footer',
+            items: [
+                {
+                    xtype: 'rallybutton',
+                    itemId: 'doneButton',
+                    text: this.selectionButtonText,
+                    cls: 'primary rly-small',
+                    scope: this,
+                    disabled: true,
+                    userAction: 'clicked done in dialog',
+                    handler: function() {
+                        this.fireEvent('itemschosen', this.getSelectedRecords());
+                        this.close();
+                    }
+                },
+                {
+                    xtype: 'rallybutton',
+                    text: 'Cancel',
+                    cls: 'secondary rly-small',
+                    handler: this.close,
+                    scope: this,
+                    ui: 'link'
+                }
+            ]
+        });
+
+        if (this.introText) {
+            this.addDocked({
+                xtype: 'component',
+                componentCls: 'intro-panel',
+                html: this.introText
+            });
+        }
+
+        if ( this.showSearchBox ) {
+            this.addDocked({
+                xtype: 'toolbar',
+                itemId: 'searchBar',
+                dock: 'top',
+                border: false,
+                padding: '0 0 10px 0',
+                items: this.getSearchBarItems()
+            });
+        }
+
+        this.buildGrid();
+
+        this.selectionCache = this.getInitialSelectedRecords() || [];
+    },
+
+    /**
+     * Get the records currently selected in the dialog
+     * {Rally.data.Model}|{Rally.data.Model[]}
+     */
+    getSelectedRecords: function() {
+        return this.multiple ? this.selectionCache : this.selectionCache[0];
+    },
+
+    getSearchBarItems: function() {
+        
+        return [
+            {
+                xtype: 'triggerfield',
+                cls: 'rui-triggerfield chooser-search-terms',
+                emptyText: 'Search Keyword or ID',
+                enableKeyEvents: true,
+                flex: 1,
+                itemId: 'searchTerms',
+                listeners: {
+                    keyup: function (textField, event) {
+                        if (event.getKey() === Ext.EventObject.ENTER) {
+                            this._search();
+                        }
+                    },
+                    afterrender: function (field) {
+                        field.focus();
+                    },
+                    scope: this
+                },
+                triggerBaseCls: 'icon-search chooser-search-icon'
+            }
+        ];
+    },
+    getStoreFilters: function() {
+        return [];
+    },
+
+    buildGrid: function() {
+        if (this.grid) {
+            this.grid.destroy();
+        }
+        var me = this;
+
+        this.setLoading('Fetching Project Tree...');
+        Ext.create('Rally.data.wsapi.ProjectTreeStoreBuilder').build({
+            models: ['project'],
+            autoLoad: true,
+            enableHierarchy: true,
+            filters: [{
+                property: 'Parent',
+                value: ""
+            }]
+        }).then({
+            scope: this,
+            success: function(store) {
+
+                var mode = this.multiple ? 'MULTI' : 'SINGLE';
+
+                var checkbox_model = Ext.create('Rally.ui.selection.CheckboxModel', {
+                    mode: mode,
+                    enableKeyNav: false,
+                    allowDeselect: true
+                });
+
+                this.grid = this.add({
+                    xtype: 'rallytreegrid',
+                    treeColumnDataIndex: 'Name',
+                    treeColumnHeader: 'Name',
+                    viewConfig: {
+                        cls: 'grid-view-bulk-edit'
+                    },
+                    enableRanking: false,
+                    enableEditing: false,
+                    enableBulkEdit: false,
+                    shouldShowRowActionsColumn: false,
+
+                    selModel: checkbox_model,
+                    _defaultTreeColumnRenderer: function (value, metaData, record, rowIdx, colIdx, store) {
+                        store = store.treeStore || store;
+                        return Rally.ui.renderer.RendererFactory.getRenderTemplate(store.model.getField('Name')).apply(record.data);
+                    },
+                    columnCfgs: [],
+                    store: store
+                });
+
+                this.mon(this.grid, {
+                    beforeselect: this._onGridSelect,
+                    beforedeselect: this._onGridDeselect,
+                    load: this._onGridLoad,
+                    scope: this
+                });
+                this.add(this.grid);
+                this._onGridReady();
+            }
+        }).always(function() { me.setLoading(false);} );
+    },
+
+    _enableDoneButton: function() {
+        this.down('#doneButton').setDisabled(this.selectionCache.length ? false : true);
+    },
+
+    _findRecordInSelectionCache: function(record){
+        return _.findIndex(this.selectionCache, function(cachedRecord) {
+            return cachedRecord.get('_ref') === record.get('_ref');
+        });
+    },
+
+    _onGridSelect: function(selectionModel, record) {
+        var index = this._findRecordInSelectionCache(record);
+
+        if (index === -1) {
+            if (!this.multiple) {
+                this.selectionCache = [];
+            }
+            this.selectionCache.push(record);
+        }
+
+        this._enableDoneButton();
+    },
+
+    _onGridDeselect: function(selectionModel, record) {
+        var index = this._findRecordInSelectionCache(record);
+        if (index !== -1) {
+            this.selectionCache.splice(index, 1);
+        }
+        this._enableDoneButton();
+    },
+
+    _onGridReady: function() {
+        if (!this.grid.rendered) {
+            this.mon(this.grid, 'afterrender', this._onGridReady, this, {single: true});
+            return;
+        }
+
+        if (this.grid.getStore().isLoading()) {
+            this.mon(this.grid, 'load', this._onGridReady, this, {single: true});
+            return;
+        }
+
+        this._onGridLoad();
+        this.center();
+    },
+    _onGridLoad: function() {
+        var store = this.grid.store;
+        var records = [];
+        Ext.Array.each(this.selectionCache, function(record) {
+            var foundNode = store.getRootNode().findChild('_ref', record.get('_ref'),true);
+
+            if (foundNode) {
+                records.push(foundNode);
+            }
+        });
+        if (records.length) {
+            this.grid.getSelectionModel().select(records);
+        }
+    },
+    _search: function() {
+        var terms = this._getSearchTerms();
+        var store = this.grid.getStore();
+        //Filter functions call store load so we don't need to refresh the selections becuaes the
+        //onGridLoad function will
+        if (terms) {
+            store.filter([
+                Ext.create('Rally.data.wsapi.Filter',{
+                    property: 'Name',
+                    operator: 'contains',
+                    value: terms
+                })
+            ]);
+        } else {
+            store.clearFilter();
+        }
+
+    },
+    _getSearchTerms: function() {
+        var textBox = this.down('#searchTerms');
+        return textBox && textBox.getValue();
+    }
+});
+
+Ext.override(Rally.data.wsapi.ParentChildMapper, {
+    constructor: function() {
+        this.parentChildTypeMap = {
+            project: [{
+                typePath: 'project', collectionName: 'Children', parentField: 'Parent'
+            }],
+            hierarchicalrequirement: [
+                {typePath: 'defect', collectionName: 'Defects', parentField: 'Requirement'},
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'WorkProduct'},
+                {typePath: 'hierarchicalrequirement', collectionName: 'Children', parentField: 'Parent'}
+            ],
+            defect: [
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'WorkProduct'}
+            ],
+            defectsuite: [
+                {typePath: 'defect', collectionName: 'Defects', parentField: 'DefectSuites'},
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'WorkProduct'}
+            ],
+            testset: [
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'TestSets'}
+            ]
+        };
+    }
+});
+
+
+Ext.define('Rally.data.wsapi.ProjectTreeStore', {
+
+    extend: 'Rally.data.wsapi.TreeStore',
+    alias: 'store.rallyprojectwsapitreestore',
+    
+    /**
+     * The type definition typePaths to render as root items (required)
+     * @cfg {String[]} parentTypes
+     */
+    parentTypes: ['project'],
+    
+    /**
+     * @property
+     * @private
+     */
+    childLevelSorters: [{
+        property: 'Name',
+        direction: 'ASC'
+    }],
+        
+    getParentFieldNamesByChildType: function(childType, parentType) {
+        return ['Parent'];
+    },
+
+    _getChildNodeFilters: function(node) {
+        var parentType = node.self.typePath,
+            childTypes = this._getChildTypePaths([parentType]),
+            parentFieldNames = this._getParentFieldNames(childTypes, parentType);
+
+        var filter = [];
+        if (parentFieldNames.length) {
+            filter =  [
+                Rally.data.wsapi.Filter.or(_.map(parentFieldNames, function(parentFieldName) {
+                    return {
+                        property: parentFieldName,
+                        operator: '=',
+                        value: node.get('_ref')
+                    };
+                }))
+            ];
+        }
+
+        return filter;
+    },
+
+    filter: function(filters) {
+        console.log('--');
+        this.fireEvent('beforefilter', this);
+        //We need to clear the filters to remove the Parent filter
+        this.filters.clear();
+        this.filters.addAll(filters);
+        this._resetCurrentPage();
+        this.load();
+    },
+    
+    load: function(options) {
+        this.recordLoadBegin({description: 'tree store load', component: this.requester});
+
+        this._hasErrors = false;
+
+        this.on('beforeload', function(store, operation) {
+            delete operation.id;
+        }, this, { single: true });
+
+        options = this._configureLoad(options);
+        options.originalCallback = options.callback;
+        var deferred = Ext.create('Deft.Deferred'),
+            me = this;
+
+        options.callback = function (records, operation, success) {
+            me.dataLoaded = true;
+
+            if (me._pageIsEmpty(operation)) {
+                me._reloadEmptyPage(options).then({
+                    success: function (records) {
+                        // this gives a maximum callstack exceeded error.  don't know why
+                        //me._resolveLoadingRecords(deferred, records, options, operation, success);
+                    },
+                    failure: function() {
+                        me._rejectLoadingRecord(deferred, options, operation);
+                    }
+                });
+            } else {
+                //me._resolveLoadingRecords(deferred, records, options, operation, success);
+            }
+        };
+
+        if (this._isViewReady()) {
+            this._beforeInitialLoad(options);
+        }
+
+        this.callParent([options]);
+
+        return deferred.promise;
+    },
+
+    clearFilter: function(suppressEvent) {
+        this._resetCurrentPage();
+        this.filters.clear();
+        //We need to add the parent filter back in
+        this.filters.addAll(Ext.create('Rally.data.wsapi.Filter',{
+            property: 'Parent',
+            value: ''
+        }));
+
+        if (!suppressEvent) {
+            this.load();
+        }
+    }
+});
+
+Ext.define('Rally.data.wsapi.ProjectTreeStoreBuilder', {
+    extend: 'Rally.data.wsapi.TreeStoreBuilder',
+
+    build: function(config) {
+        config = _.clone(config || {});
+        config.storeType = 'Rally.data.wsapi.ProjectTreeStore';
+
+        return this.loadModels(config).then({
+            success: function(models) {
+                models = _.values(models);
+                return this._buildStoreWithModels(models, config);
+            },
+            scope: this
+        });
+    },
+
+    _useCompositeArtifacts: function (models, config) {
+        return false;
+    }
+});
+Ext.define('CA.technicalservices.ProjectTreePickerSettingsField',{
+    extend: 'Ext.form.field.Base',
+    alias: 'widget.tsprojectsettingsfield',
+    fieldSubTpl: '<div id="{id}" class="settings-grid"></div>',
+    width: '100%',
+    cls: 'column-settings',
+
+    store: undefined,
+    labelAlign: 'top',
+    
+    onDestroy: function() {
+        if (this._grid) {
+            this._grid.destroy();
+            delete this._grid;
+        }
+        this.callParent(arguments);
+    },
+    
+    initComponent: function(){
+
+        this.callParent();
+        this.addEvents('ready');
+
+        this.setLoading('loading...');
+        var store = Ext.create('Rally.data.wsapi.Store', {
+            model: 'Project',
+            fetch: ['Name','ObjectID'],
+            //filters: [{property:'ObjectID', value: -1 }],
+            pageSize: 2000,
+            limit: 'Infinity'
+        });
+        store.load({
+            scope: this,
+            callback: this._buildProjectGrid
+        });
+
+    },
+
+    onRender: function() {
+        this.callParent(arguments);
+        this.setLoading('Loading projects...');
+    },
+        
+    _buildProjectGrid: function(records, operation, success){
+        this.setLoading(false);
+        var container = Ext.create('Ext.container.Container',{
+            layout: { type:'hbox' },
+            renderTo: this.inputEl,
+            minHeight: 50,
+            minWidth: 50
+        });
+        
+        var decodedValue = {};
+        
+        if (this.initialConfig && this.initialConfig.value && !_.isEmpty(this.initialConfig.value)){
+            if (!Ext.isObject(this.initialConfig.value)){
+                decodedValue = Ext.JSON.decode(this.initialConfig.value);
+            } else {
+                decodedValue = this.initialConfig.value;
+            }
+        }
+       
+        var data = [],
+            empty_text = "No selections";
+
+        console.log('initial config', this._value, this.initialConfig, decodedValue);
+            
+        if (success && decodedValue !== {} ) {
+            Ext.Array.each(records, function(project){
+                var setting = decodedValue[project.get('_ref')];
+                if ( setting && setting !== {} ) {
+                    data.push({
+                        _ref: project.get('_ref'), 
+                        projectName: project.get('Name'),
+                        Name: project.get('Name'),
+                        ObjectID: project.get('ObjectID')
+                    });
+                }
+            });
+        } else {
+            empty_text = "Error(s) fetching Project data: <br/>" + operation.error.errors.join('<br/>');
+        }
+
+        var custom_store = Ext.create('Ext.data.Store', {
+            fields: ['_ref', 'projectName','Name', 'ObjectID'],
+            data: data
+        });
+        
+        var gridWidth = Math.min(this.inputEl.getWidth(true)-100, 500);
+        this.inputEl.set
+        this._grid = container.add(  {
+            xtype:'rallygrid',
+            autoWidth: true,
+            columnCfgs: this._getColumnCfgs(),
+            showRowActionsColumn:false,
+            showPagingToolbar: false,
+            store: custom_store,
+            height: 150,
+            width: gridWidth,
+            emptyText: empty_text,
+            editingConfig: {
+                publishMessages: false
+            }
+        });
+
+        var width = Math.min(this.inputEl.getWidth(true)-20, 600);
+        
+        //Ext.create('Rally.ui.Button',{
+        container.add({
+            xtype: 'rallybutton',
+            text: 'Select Programs',
+            margin: '0 0 0 10',
+            listeners: {
+                scope: this,
+                click: function(){
+
+                    Ext.create('CA.technicalservices.ProjectTreePickerDialog',{
+                        autoShow: true,
+                        width: width,
+                        selectedRefs: _.pluck(data, '_ref'),
+                        listeners: {
+                            scope: this,
+                            itemschosen: function(items){
+                                var new_data = [],
+                                    store = this._grid.getStore();
+
+                                Ext.Array.each(items, function(item){
+                                    if (!store.findRecord('_ref',item.get('_ref'))){
+                                        new_data.push({
+                                            _ref: item.get('_ref'),
+                                            projectName: item.get('Name'),
+                                            Name: item.get('Name'),
+                                            ObjectID: item.get('ObjectID')
+                                        });
+                                    }
+                                });
+                                this._grid.getStore().add(new_data);
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+       this.fireEvent('ready', true);
+    },
+    _removeProject: function(){
+        this.grid.getStore().remove(this.record);
+    },
+    _getColumnCfgs: function() {
+        var me = this;
+
+        var columns = [{
+            xtype: 'rallyrowactioncolumn',
+            scope: this,
+            rowActionsFn: function(record){
+                return  [
+                    {text: 'Remove', record: record, handler: me._removeProject, grid: me._grid }
+                ];
+            }
+        },
+        {
+            text: 'Program',
+            dataIndex: '_ref',
+            flex: 1,
+            editor: false,
+            renderer: function(v, m, r){
+                return r.get('projectName');
+            },
+            getSortParam: function(v,m,r){
+                return 'projectName';
+            }
+        }];
+        return columns;
+    },
+    /**
+     * When a form asks for the data this field represents,
+     * give it the name of this field and the ref of the selected project (or an empty string).
+     * Used when persisting the value of this field.
+     * @return {Object}
+     */
+    getSubmitData: function() {
+        var data = {};
+        data[this.name] = Ext.JSON.encode(this._buildSettingValue());
+        return data;
+    },
+    
+    _buildSettingValue: function() {
+        var mappings = {};
+        var store = this._grid.getStore();
+
+        store.each(function(record) {
+            if (record.get('_ref')) {
+                mappings[record.get('_ref')] = {
+                    'Name': record.get('projectName') || "",
+                    'ObjectID': record.get('ObjectID') || "",
+                    '_ref': record.get('_ref') || ""
+                }
+            }
+        }, this);
+        return mappings;
+    },
+
+    getErrors: function() {
+        var errors = [];
+        //Add validation here
+        return errors;
+    },
+    setValue: function(value) {
+        console.log('setValue', value);
+        this.callParent(arguments);
+        this._value = value;
+    }
+});
 Ext.define('CA.technicalservices.Toolbox', {
     singleton: true,
 
@@ -985,7 +2336,7 @@ Ext.define('CA.techservices.validator.Validator',{
                     };
 
                 Ext.Array.each(projectGroups, function(pg){
-                    hash[pg.groupName] = results[idx++];
+                    hash[pg.Name] = results[idx++];
                 });
                 deferred.resolve(hash);
             },
@@ -1600,17 +2951,18 @@ Ext.define('CA.techservices.validation.BaseRule',{
             strategyConfig = {
                 model: this.getModel(),
                 filters: filters,
-                context: {project: pg.strategyProjectRef, projectScopeDown: true}
-            },
-            executionConfig = {
-                model: this.getModel(),
-                filters: filters,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
+            //,
+            // executionConfig = {
+            //     model: this.getModel(),
+            //     filters: filters,
+            //     context: {project: pg.executionProjectRef, projectScopeDown: true}
+            // };
 
         Deft.Promise.all([
             this._loadWsapiRecords(strategyConfig),
-            this._loadWsapiRecords(executionConfig)
+            // this._loadWsapiRecords(executionConfig)
         ]).then({
             success: function(results){
                 // deferred.resolve(Ext.Array.sum(results));
@@ -2000,8 +3352,8 @@ Ext.define('CA.techservices.validation.PortfolioProject',{
         portfolioItemTypes:[],
         targetPortfolioLevel: 0,
         portfolioProjects: [],
-        label: '{0}s with incorrect "Project" field value --> should be "Portfolio" or "Sub-Portfolio"',
-        description: '{0}s with incorrect "Project" field value --> should be "Portfolio" or "Sub-Portfolio"'
+        label: '{0}s with incorrect "Project" field value --> should be "Program" or "Sub-Program"',
+        description: '{0}s with incorrect "Project" field value --> should be "Program" or "Sub-Program"'
     },
     getModel:function(){
         return this.portfolioItemTypes[this.targetPortfolioLevel].TypePath;
@@ -2020,11 +3372,25 @@ Ext.define('CA.techservices.validation.PortfolioProject',{
             filters = filters.and(baseFilters);
         }
 
+        var deliveryFilters = [{
+            property: "Project.Name",
+            operator: '!contains',
+            value: 'Program'
+        },
+        {
+            property: "Project.Name",
+            operator: '!contains',
+            value: 'Sub-Program'
+        }
+        ];
+
+        filters = filters.and(Rally.data.wsapi.Filter.and(deliveryFilters));
+
         var deferred = Ext.create('Deft.Deferred'),
             executionConfig = {
                 model: this.getModel(),
                 filters: filters,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
 
         this._loadWsapiRecords(executionConfig).then({
@@ -2253,21 +3619,21 @@ Ext.define('CA.techservices.validation.StoryMismatchedRelease',{
             strategyConfig = {
                 model: this.getModel(),
                 filters: filters,
-                fetch: ['Release','Name',featureName],
+                fetch: ['FormattedID','Owner','Release','Name',featureName],
                 compact: false,
-                context: {project: pg.strategyProjectRef, projectScopeDown: true}
-            },
-            executionConfig = {
-                model: this.getModel(),
-                filters: filters,
-                fetch: ['Release','Name',featureName],
-                compact: false,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
+            // executionConfig = {
+            //     model: this.getModel(),
+            //     filters: filters,
+            //     fetch: ['Release','Name',featureName],
+            //     compact: false,
+            //     context: {project: pg.executionProjectRef, projectScopeDown: true}
+            // };
 
         Deft.Promise.all([
             this._loadWsapiRecords(strategyConfig),
-            this._loadWsapiRecords(executionConfig)
+            //this._loadWsapiRecords(executionConfig)
         ]).then({
             success: function(results){
                 var filtered_records = [];
@@ -2359,6 +3725,71 @@ Ext.define('CA.techservices.validation.StoryOrphan',{
         }]);
     }
 });
+Ext.define('CA.techservices.validation.StoryProjectTrack',{
+    extend: 'CA.techservices.validation.BaseRule',
+    alias:  'widget.tsstory_project_track',
+
+
+    config: {
+        /*
+         * [{Rally.wsapi.data.Model}] portfolioItemTypes the list of PIs available
+         * we're going to use the first level ones (different workspaces name their portfolio item levels differently)
+         */
+        portfolioItemTypes:[],
+        model: 'HierarchicalRequirement',
+        label: 'Stories with Project field value "Track"',
+        description: 'Stories with Project field value "Track"'
+    },
+    getFetchFields: function() {
+        return ['Name','Project'];
+    },
+    apply: function(pg, baseFilters){
+        var filters = this.getFilters();
+        if (baseFilters){
+            filters = filters.and(baseFilters);
+        }
+
+        var deliveryFilters = filters.and({
+            property: "Project.Name",
+            operator: 'contains',
+            value: 'Track'
+        });
+        
+        var deferred = Ext.create('Deft.Deferred'),
+            executionConfig = {
+                model: this.getModel(),
+                filters: deliveryFilters,
+                context: {project: pg._ref, projectScopeDown: true}
+            };
+            // ,
+            // deliveryConfig = {
+            //     model: this.getModel(),
+            //     filters: deliveryFilters,
+            //     context: {project: pg.executionProjectRef, projectScopeDown: true}
+            // };
+
+        var promises = [
+            this._loadWsapiRecords(executionConfig),
+            // this._loadWsapiRecords(deliveryConfig)
+        ];
+
+        Deft.Promise.all(promises).then({
+            success: function(results){
+                console.log('results', results);
+                //deferred.resolve(Ext.Array.sum(results));
+                deferred.resolve(results);
+            },
+            failure: function(msg){
+                deferred.reject(msg);
+            },
+            scope: this
+        });
+        return deferred.promise;
+    },
+    getFilters: function(){
+        return Rally.data.wsapi.Filter.fromQueryString("(ObjectID > 0)");
+    }
+});
 Ext.define('CA.techservices.validation.StoryProject',{
     extend: 'CA.techservices.validation.BaseRule',
     alias:  'widget.tsstory_project',
@@ -2391,18 +3822,19 @@ Ext.define('CA.techservices.validation.StoryProject',{
         var deferred = Ext.create('Deft.Deferred'),
             executionConfig = {
                 model: this.getModel(),
-                filters: filters,
-                context: {project: pg.strategyProjectRef, projectScopeDown: true}
-            },
-            deliveryConfig = {
-                model: this.getModel(),
                 filters: deliveryFilters,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
+            // ,
+            // deliveryConfig = {
+            //     model: this.getModel(),
+            //     filters: deliveryFilters,
+            //     context: {project: pg.executionProjectRef, projectScopeDown: true}
+            // };
 
         var promises = [
             this._loadWsapiRecords(executionConfig),
-            this._loadWsapiRecords(deliveryConfig)
+            // this._loadWsapiRecords(deliveryConfig)
         ];
 
         Deft.Promise.all(promises).then({
@@ -2472,7 +3904,8 @@ Ext.define("data-hygiene", {
             portfolioCRApprovalField: 'c_CRApprovedDate',
             userStoryCRField: 'c_CR',
             userStoryCRApprovalField: 'c_CRApprovedDate',
-            projectGroups: [],
+            showPrograms:[],
+            // projectGroups: [],
             query: null,
             lastUpdateDateAfter: null,
             creationDateAfter: null,
@@ -2587,7 +4020,7 @@ Ext.define("data-hygiene", {
         this.logger.log('addChart', chartData);
       
         var projects = _.map(this.getProjectGroups(), function(pg){
-            return pg.groupName;
+            return pg.Name;
         });
 
         var ruleHash = {},
@@ -2710,6 +4143,8 @@ Ext.define("data-hygiene", {
         var fileName = Ext.String.format("data-hygiene-{0}.csv",Rally.util.DateTime.format(new Date(), 'Y-m-d-h-i-s'));
         Rally.technicalservices.FileUtilities.saveCSVToFile(csv, fileName);
     },
+
+
     addExportButton: function(){
 
         var btn = this.getExportBox().add({
@@ -2792,32 +4227,103 @@ Ext.define("data-hygiene", {
         var clickedDataIndex = view.panel.headerCt.getHeaderAtIndex(cellIndex).dataIndex;
         var ruleValue = record.get(clickedDataIndex);
 
+        if(ruleValue.constructor != Array) return;
+
         var store = Ext.create('Rally.data.custom.Store', {
             data: _.flatten(ruleValue),
             pageSize: 2000
         });
         
         var title = record.data.ruleName + ' for ' + clickedDataIndex || ""
+
+
+        var export_popup = function(){
+            var grid = this.down('#popupGrid');
+            var me = this;
+
+            if ( !grid ) { return; }
+            
+            this.logger.log('_export',grid);
+
+            var filename = Ext.String.format('pi-timesheet-report.csv');
+
+            this.setLoading("Generating CSV");
+            Deft.Chain.sequence([
+                function() { return Rally.technicalservices.FileUtilities._getCSVFromCustomBackedGrid(grid) } 
+            ]).then({
+                scope: this,
+                success: function(csv){
+                    if (csv && csv.length > 0){
+                        Rally.technicalservices.FileUtilities.saveCSVToFile(csv,filename);
+                    } else {
+                        Rally.ui.notify.Notifier.showWarning({message: 'No data to export'});
+                    }
+                    
+                }
+            }).always(function() { me.setLoading(false); });
+        };
         
         Ext.create('Rally.ui.dialog.Dialog', {
-            id        : 'detailPopup',
+            itemId    : 'detailPopup',
             title     : title,
             width     : Ext.getBody().getWidth() - 150,
             height    : Ext.getBody().getHeight() - 150,
             closable  : true,
             layout    : 'border',
             items     : [
-            {
-                xtype                : 'rallygrid',
-                region               : 'center',
-                layout               : 'fit',
-                sortableColumns      : true,
-                showRowActionsColumn : false,
-                showPagingToolbar    : false,
-                columnCfgs           : this.getDrillDownColumns(title),
-                store : store
-            }]
+                        {
+                            xtype                : 'rallygrid',
+                            itemId               : 'popupGrid',
+                            region               : 'center',
+                            layout               : 'fit',
+                            sortableColumns      : true,
+                            showRowActionsColumn : false,
+                            showPagingToolbar    : false,
+                            columnCfgs           : this.getDrillDownColumns(title),
+                            store : store,
+                            dockedItems: [{
+                                xtype: 'toolbar',
+                                dock: 'top',
+                                items: [
+                                    { 
+                                        xtype: 'button', 
+                                        text: 'Download CSV',
+                                        listeners: {
+                                            click: me._export_popup
+                                        }                                         
+                                    }
+                                ]
+                            }]
+                        }
+                        ]
         }).show();
+    },
+
+    _export_popup: function(){
+        var me = this;
+
+        var grid = this.up('window').down('#popupGrid');
+
+        if ( !grid ) { return; }
+        
+        //this.logger.log('_export',grid);
+
+        var filename = Ext.String.format(this.up('window').title +'.csv');
+
+        this.up('window').setLoading("Generating CSV");
+        Deft.Chain.sequence([
+            function() { return Rally.technicalservices.FileUtilities._getCSVFromCustomBackedGrid(grid) } 
+        ]).then({
+            scope: this,
+            success: function(csv){
+                if (csv && csv.length > 0){
+                    Rally.technicalservices.FileUtilities.saveCSVToFile(csv,filename);
+                } else {
+                    Rally.ui.notify.Notifier.showWarning({message: 'No data to export'});
+                }
+                
+            }
+        }).always(function() { this.up('window').setLoading(false); });
     },
 
     getDrillDownColumns: function(title) {
@@ -2825,9 +4331,12 @@ Ext.define("data-hygiene", {
             {
                 dataIndex: 'FormattedID',
                 text: "id",
-                renderer: function(m,v,r){
-                  return Ext.create('Rally.ui.renderer.template.FormattedIDTemplate').apply(r.data);
-                }
+                // renderer: function(m,v,r){
+                //   return Ext.create('Rally.ui.renderer.template.FormattedIDTemplate').apply(r.data);
+                // }
+                renderer: function(value,meta,record){
+                    return Ext.String.format("<a href='{0}' target='_new'>{1}</a>",Rally.nav.Manager.getDetailUrl(record.get('_ref')),value);
+                }                          
             },
             {
                 dataIndex : 'Name',
@@ -2886,13 +4395,13 @@ Ext.define("data-hygiene", {
     },
     getProjectGroups: function(){
         var groups = [],
-            group_setting = this.getSetting('projectGroups');
+            group_setting = this.getSetting('showPrograms');
         if (!Ext.isArray(group_setting)){
             groups = Ext.JSON.decode(group_setting);
         } else {
             groups = group_setting;
         }
-        return groups;
+        return Ext.Object.getValues(groups);
     },
     getGridBox: function(){
         return this.down('#grid_box');
@@ -2921,7 +4430,8 @@ Ext.define("data-hygiene", {
             portfolioItemTypes: this.portfolioItemTypes,
             portfolioItemStates: this.portfolioItemStates,
             projectGroups: this.getProjectGroups()
-        },{
+        },
+        //{
         //    xtype: 'tsportfolio_fieldvalue',
         //    targetPortfolioLevel: 1,
         //    portfolioItemTypes: this.portfolioItemTypes,
@@ -2930,16 +4440,18 @@ Ext.define("data-hygiene", {
         //    description: '{0}s with "AOP Approved" field checked',
         //    targetFieldValue: true,
         //    projectGroups: this.getProjectGroups()
-        //},{
-            xtype: 'tsportfolio_fieldvalue',
-            targetPortfolioLevel: 1,
-            portfolioItemTypes: this.portfolioItemTypes,
-            targetField: this.getPortfolioAOPField(),
-            label: '{0}s not "AOP Approved"',
-            description: '{0}s not "AOP Approved"',
-            targetFieldValue: "No",
-            projectGroups: this.getProjectGroups()
-        },{
+        //},
+        // {
+        //     xtype: 'tsportfolio_fieldvalue',
+        //     targetPortfolioLevel: 1,
+        //     portfolioItemTypes: this.portfolioItemTypes,
+        //     targetField: this.getPortfolioAOPField(),
+        //     label: '{0}s not "AOP Approved"',
+        //     description: '{0}s not "AOP Approved"',
+        //     targetFieldValue: "No",
+        //     projectGroups: this.getProjectGroups()
+        // },
+        {
             xtype:'tsportfolio_orphan',
             targetPortfolioLevel: 0,
             portfolioItemTypes: this.portfolioItemTypes,
@@ -2949,16 +4461,18 @@ Ext.define("data-hygiene", {
             targetPortfolioLevel: 0,
             portfolioItemTypes: this.portfolioItemTypes,
             projectGroups: this.getProjectGroups()
-        },{
-            xtype: 'tsportfolio_fieldvalue',
-            targetPortfolioLevel: 0,
-            portfolioItemTypes: this.portfolioItemTypes,
-            targetField: this.getPortfolioCRField(),
-            label: '{0}s with "CR" field checked',
-            description: '{0}s with "CR" field checked',
-            targetFieldValue: true,
-            projectGroups: this.getProjectGroups()
-        //},{
+        },
+        // {
+        //     xtype: 'tsportfolio_fieldvalue',
+        //     targetPortfolioLevel: 0,
+        //     portfolioItemTypes: this.portfolioItemTypes,
+        //     targetField: this.getPortfolioCRField(),
+        //     label: '{0}s with "CR" field checked',
+        //     description: '{0}s with "CR" field checked',
+        //     targetFieldValue: true,
+        //     projectGroups: this.getProjectGroups()
+        //}
+        // ,{
         //    xtype: 'tsportfolio_fieldvalue',
         //    targetPortfolioLevel: 0,
         //    portfolioItemTypes: this.portfolioItemTypes,
@@ -2967,7 +4481,8 @@ Ext.define("data-hygiene", {
         //    description: '{0}s with "CR" field <b>not</b> checked',
         //    targetFieldValue: false,
         //    projectGroups: this.getProjectGroups()
-        },{
+        // },
+        {
             xtype: 'tsportfolio_staterelease',
             portfolioItemTypes: this.portfolioItemTypes,
             portfolioItemStates: this.portfolioItemStates
@@ -3014,7 +4529,7 @@ Ext.define("data-hygiene", {
         //     targetFieldValue: true,
         //     projectGroups: this.getProjectGroups()
         // },
-        {
+        //{
         //    xtype: 'tsstory_fieldvalue',
         //    targetField: this.getStoryCRField(),
         //    label: 'User Stories with "CR" field <b>not</b> checked',
@@ -3025,10 +4540,14 @@ Ext.define("data-hygiene", {
         //    xtype: 'tsstory_inprogressbeforeexecution',
         //    portfolioItemTypes: this.portfolioItemTypes,
         //    portfolioItemStates: this.portfolioItemStates
-        //},{
+        //},
+        {
             xtype: 'tsstory_inprogresscrcheckednoapproval',
             crField: this.getStoryCRField(),
             crApprovalField: this.getStoryCRApprovalField()
+        },{
+            xtype:'tsstory_project_track',
+            projectGroups: this.getProjectGroups()
         }];
 
         var validator = Ext.create('CA.techservices.validator.Validator',{
@@ -3072,11 +4591,19 @@ Ext.define("data-hygiene", {
             xtype: 'container',
             margin: '25 0 0 0',
             html: '<div class="rally-upper-bold">Programs</div>'
-        },{
-            name: 'projectGroups',
-            xtype:'tsstrategyexecutiongroupsettingsfield',
-            fieldLabel: ' '
-        },{
+        },
+        // {
+        //     name: 'projectGroups',
+        //     xtype:'tsstrategyexecutiongroupsettingsfield',
+        //     fieldLabel: ' '
+        // },
+        {
+            name: 'showPrograms',
+            xtype:'tsprojectsettingsfield',
+            fieldLabel: ' ',
+            readyEvent: 'ready'
+        },        
+        {
             xtype: 'textarea',
             fieldLabel: '<div class="rally-upper-bold">Filter by Query</div><em>Query fields must apply to all item types.  This filter will override the date filters above for all item types.</em>',
             labelAlign: 'top',

--- a/data-hygiene/src/javascript/rules/__ts-validation-rule-base.js
+++ b/data-hygiene/src/javascript/rules/__ts-validation-rule-base.js
@@ -62,17 +62,18 @@ Ext.define('CA.techservices.validation.BaseRule',{
             strategyConfig = {
                 model: this.getModel(),
                 filters: filters,
-                context: {project: pg.strategyProjectRef, projectScopeDown: true}
-            },
-            executionConfig = {
-                model: this.getModel(),
-                filters: filters,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
+            //,
+            // executionConfig = {
+            //     model: this.getModel(),
+            //     filters: filters,
+            //     context: {project: pg.executionProjectRef, projectScopeDown: true}
+            // };
 
         Deft.Promise.all([
             this._loadWsapiRecords(strategyConfig),
-            this._loadWsapiRecords(executionConfig)
+            // this._loadWsapiRecords(executionConfig)
         ]).then({
             success: function(results){
                 // deferred.resolve(Ext.Array.sum(results));

--- a/data-hygiene/src/javascript/rules/_ts-portfolio-project.js
+++ b/data-hygiene/src/javascript/rules/_ts-portfolio-project.js
@@ -11,8 +11,8 @@ Ext.define('CA.techservices.validation.PortfolioProject',{
         portfolioItemTypes:[],
         targetPortfolioLevel: 0,
         portfolioProjects: [],
-        label: '{0}s with incorrect "Project" field value --> should be "Portfolio" or "Sub-Portfolio"',
-        description: '{0}s with incorrect "Project" field value --> should be "Portfolio" or "Sub-Portfolio"'
+        label: '{0}s with incorrect "Project" field value --> should be "Program" or "Sub-Program"',
+        description: '{0}s with incorrect "Project" field value --> should be "Program" or "Sub-Program"'
     },
     getModel:function(){
         return this.portfolioItemTypes[this.targetPortfolioLevel].TypePath;
@@ -31,11 +31,25 @@ Ext.define('CA.techservices.validation.PortfolioProject',{
             filters = filters.and(baseFilters);
         }
 
+        var deliveryFilters = [{
+            property: "Project.Name",
+            operator: '!contains',
+            value: 'Program'
+        },
+        {
+            property: "Project.Name",
+            operator: '!contains',
+            value: 'Sub-Program'
+        }
+        ];
+
+        filters = filters.and(Rally.data.wsapi.Filter.and(deliveryFilters));
+
         var deferred = Ext.create('Deft.Deferred'),
             executionConfig = {
                 model: this.getModel(),
                 filters: filters,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
 
         this._loadWsapiRecords(executionConfig).then({

--- a/data-hygiene/src/javascript/rules/_ts-story-mismatched-release.js
+++ b/data-hygiene/src/javascript/rules/_ts-story-mismatched-release.js
@@ -28,21 +28,21 @@ Ext.define('CA.techservices.validation.StoryMismatchedRelease',{
             strategyConfig = {
                 model: this.getModel(),
                 filters: filters,
-                fetch: ['Release','Name',featureName],
+                fetch: ['FormattedID','Owner','Release','Name',featureName],
                 compact: false,
-                context: {project: pg.strategyProjectRef, projectScopeDown: true}
-            },
-            executionConfig = {
-                model: this.getModel(),
-                filters: filters,
-                fetch: ['Release','Name',featureName],
-                compact: false,
-                context: {project: pg.executionProjectRef, projectScopeDown: true}
+                context: {project: pg._ref, projectScopeDown: true}
             };
+            // executionConfig = {
+            //     model: this.getModel(),
+            //     filters: filters,
+            //     fetch: ['Release','Name',featureName],
+            //     compact: false,
+            //     context: {project: pg.executionProjectRef, projectScopeDown: true}
+            // };
 
         Deft.Promise.all([
             this._loadWsapiRecords(strategyConfig),
-            this._loadWsapiRecords(executionConfig)
+            //this._loadWsapiRecords(executionConfig)
         ]).then({
             success: function(results){
                 var filtered_records = [];

--- a/data-hygiene/src/javascript/rules/_ts-story-project-track.js
+++ b/data-hygiene/src/javascript/rules/_ts-story-project-track.js
@@ -1,6 +1,6 @@
-Ext.define('CA.techservices.validation.StoryProject',{
+Ext.define('CA.techservices.validation.StoryProjectTrack',{
     extend: 'CA.techservices.validation.BaseRule',
-    alias:  'widget.tsstory_project',
+    alias:  'widget.tsstory_project_track',
 
 
     config: {
@@ -10,8 +10,8 @@ Ext.define('CA.techservices.validation.StoryProject',{
          */
         portfolioItemTypes:[],
         model: 'HierarchicalRequirement',
-        label: 'Stories with incorrect "Project" field value --> should be "Team"',
-        description: 'Stories with incorrect "Project" field value --> should be "Team"'
+        label: 'Stories with Project field value "Track"',
+        description: 'Stories with Project field value "Track"'
     },
     getFetchFields: function() {
         return ['Name','Project'];
@@ -24,9 +24,10 @@ Ext.define('CA.techservices.validation.StoryProject',{
 
         var deliveryFilters = filters.and({
             property: "Project.Name",
-            operator: '!contains',
-            value: 'Team'
+            operator: 'contains',
+            value: 'Track'
         });
+        
         var deferred = Ext.create('Deft.Deferred'),
             executionConfig = {
                 model: this.getModel(),

--- a/data-hygiene/src/javascript/utils/FileSaver-LICENSE.md
+++ b/data-hygiene/src/javascript/utils/FileSaver-LICENSE.md
@@ -1,0 +1,9 @@
+Copyright � 2014 [Eli Grey][1].
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+  [1]: http://eligrey.com

--- a/data-hygiene/src/javascript/utils/FileSaver.js
+++ b/data-hygiene/src/javascript/utils/FileSaver.js
@@ -1,0 +1,241 @@
+/* FileSaver.js
+ *  A saveAs() FileSaver implementation.
+ *  2014-05-27
+ *
+ *  By Eli Grey, http://eligrey.com
+ *  License: X11/MIT
+ *    See https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+ */
+
+/*global self */
+/*jslint bitwise: true, indent: 4, laxbreak: true, laxcomma: true, smarttabs: true, plusplus: true */
+
+/*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
+
+var saveAs = saveAs
+  // IE 10+ (native saveAs)
+  || (typeof navigator !== "undefined" &&
+      navigator.msSaveOrOpenBlob && navigator.msSaveOrOpenBlob.bind(navigator))
+  // Everyone else
+  || (function(view) {
+    "use strict";
+    // IE <10 is explicitly unsupported
+    if (typeof navigator !== "undefined" &&
+        /MSIE [1-9]\./.test(navigator.userAgent)) {
+        return;
+    }
+    var
+          doc = view.document
+          // only get URL when necessary in case Blob.js hasn't overridden it yet
+        , get_URL = function() {
+            return view.URL || view.webkitURL || view;
+        }
+        , save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a")
+        , can_use_save_link = !view.externalHost && "download" in save_link
+        , click = function(node) {
+            var event = doc.createEvent("MouseEvents");
+            event.initMouseEvent(
+                "click", true, false, view, 0, 0, 0, 0, 0
+                , false, false, false, false, 0, null
+            );
+            node.dispatchEvent(event);
+        }
+        , webkit_req_fs = view.webkitRequestFileSystem
+        , req_fs = view.requestFileSystem || webkit_req_fs || view.mozRequestFileSystem
+        , throw_outside = function(ex) {
+            (view.setImmediate || view.setTimeout)(function() {
+                throw ex;
+            }, 0);
+        }
+        , force_saveable_type = "application/octet-stream"
+        , fs_min_size = 0
+        , deletion_queue = []
+        , process_deletion_queue = function() {
+            var i = deletion_queue.length;
+            while (i--) {
+                var file = deletion_queue[i];
+                if (typeof file === "string") { // file is an object URL
+                    get_URL().revokeObjectURL(file);
+                } else { // file is a File
+                    file.remove();
+                }
+            }
+            deletion_queue.length = 0; // clear queue
+        }
+        , dispatch = function(filesaver, event_types, event) {
+            event_types = [].concat(event_types);
+            var i = event_types.length;
+            while (i--) {
+                var listener = filesaver["on" + event_types[i]];
+                if (typeof listener === "function") {
+                    try {
+                        listener.call(filesaver, event || filesaver);
+                    } catch (ex) {
+                        throw_outside(ex);
+                    }
+                }
+            }
+        }
+        , FileSaver = function(blob, name) {
+            // First try a.download, then web filesystem, then object URLs
+            var
+                  filesaver = this
+                , type = blob.type
+                , blob_changed = false
+                , object_url
+                , target_view
+                , get_object_url = function() {
+                    var object_url = get_URL().createObjectURL(blob);
+                    deletion_queue.push(object_url);
+                    return object_url;
+                }
+                , dispatch_all = function() {
+                    dispatch(filesaver, "writestart progress write writeend".split(" "));
+                }
+                // on any filesys errors revert to saving with object URLs
+                , fs_error = function() {
+                    // don't create more object URLs than needed
+                    if (blob_changed || !object_url) {
+                        object_url = get_object_url(blob);
+                    }
+                    if (target_view) {
+                        target_view.location.href = object_url;
+                    } else {
+                        window.open(object_url, "_blank");
+                    }
+                    filesaver.readyState = filesaver.DONE;
+                    dispatch_all();
+                }
+                , abortable = function(func) {
+                    return function() {
+                        if (filesaver.readyState !== filesaver.DONE) {
+                            return func.apply(this, arguments);
+                        }
+                    };
+                }
+                , create_if_not_found = {create: true, exclusive: false}
+                , slice
+            ;
+            filesaver.readyState = filesaver.INIT;
+            if (!name) {
+                name = "download";
+            }
+            if (can_use_save_link) {
+                object_url = get_object_url(blob);
+                save_link.href = object_url;
+                save_link.download = name;
+                click(save_link);
+                filesaver.readyState = filesaver.DONE;
+                dispatch_all();
+                return;
+            }
+            // Object and web filesystem URLs have a problem saving in Google Chrome when
+            // viewed in a tab, so I force save with application/octet-stream
+            // http://code.google.com/p/chromium/issues/detail?id=91158
+            if (view.chrome && type && type !== force_saveable_type) {
+                slice = blob.slice || blob.webkitSlice;
+                blob = slice.call(blob, 0, blob.size, force_saveable_type);
+                blob_changed = true;
+            }
+            // Since I can't be sure that the guessed media type will trigger a download
+            // in WebKit, I append .download to the filename.
+            // https://bugs.webkit.org/show_bug.cgi?id=65440
+            if (webkit_req_fs && name !== "download") {
+                name += ".download";
+            }
+            if (type === force_saveable_type || webkit_req_fs) {
+                target_view = view;
+            }
+            if (!req_fs) {
+                fs_error();
+                return;
+            }
+            fs_min_size += blob.size;
+            req_fs(view.TEMPORARY, fs_min_size, abortable(function(fs) {
+                fs.root.getDirectory("saved", create_if_not_found, abortable(function(dir) {
+                    var save = function() {
+                        dir.getFile(name, create_if_not_found, abortable(function(file) {
+                            file.createWriter(abortable(function(writer) {
+                                writer.onwriteend = function(event) {
+                                    target_view.location.href = file.toURL();
+                                    deletion_queue.push(file);
+                                    filesaver.readyState = filesaver.DONE;
+                                    dispatch(filesaver, "writeend", event);
+                                };
+                                writer.onerror = function() {
+                                    var error = writer.error;
+                                    if (error.code !== error.ABORT_ERR) {
+                                        fs_error();
+                                    }
+                                };
+                                "writestart progress write abort".split(" ").forEach(function(event) {
+                                    writer["on" + event] = filesaver["on" + event];
+                                });
+                                writer.write(blob);
+                                filesaver.abort = function() {
+                                    writer.abort();
+                                    filesaver.readyState = filesaver.DONE;
+                                };
+                                filesaver.readyState = filesaver.WRITING;
+                            }), fs_error);
+                        }), fs_error);
+                    };
+                    dir.getFile(name, {create: false}, abortable(function(file) {
+                        // delete file if it already exists
+                        file.remove();
+                        save();
+                    }), abortable(function(ex) {
+                        if (ex.code === ex.NOT_FOUND_ERR) {
+                            save();
+                        } else {
+                            fs_error();
+                        }
+                    }));
+                }), fs_error);
+            }), fs_error);
+        }
+        , FS_proto = FileSaver.prototype
+        , saveAs = function(blob, name) {
+            return new FileSaver(blob, name);
+        }
+    ;
+    FS_proto.abort = function() {
+        var filesaver = this;
+        filesaver.readyState = filesaver.DONE;
+        dispatch(filesaver, "abort");
+    };
+    FS_proto.readyState = FS_proto.INIT = 0;
+    FS_proto.WRITING = 1;
+    FS_proto.DONE = 2;
+
+    FS_proto.error =
+    FS_proto.onwritestart =
+    FS_proto.onprogress =
+    FS_proto.onwrite =
+    FS_proto.onabort =
+    FS_proto.onerror =
+    FS_proto.onwriteend =
+        null;
+
+    view.addEventListener("unload", process_deletion_queue, false);
+    saveAs.unload = function() {
+        process_deletion_queue();
+        view.removeEventListener("unload", process_deletion_queue, false);
+    };
+    return saveAs;
+}(
+       typeof self !== "undefined" && self
+    || typeof window !== "undefined" && window
+    || this.content
+));
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window
+
+if (typeof module !== "undefined" && module !== null) {
+  module.exports = saveAs;
+} else if ((typeof define !== "undefined" && define !== null) && (define.amd != null)) {
+  define([], function() {
+    return saveAs;
+  });
+}

--- a/data-hygiene/src/javascript/utils/_ts-file-utils.js
+++ b/data-hygiene/src/javascript/utils/_ts-file-utils.js
@@ -1,0 +1,377 @@
+Ext.define('Rally.technicalservices.FileUtilities', {
+    singleton: true,
+    logger: new Rally.technicalservices.Logger(),
+    saveCSVToFile:function(csv,file_name,type_object){
+            if (type_object == undefined){
+                type_object = {type:'text/csv;charset=utf-8'};
+            }
+            var blob = new Blob([csv],type_object);
+            saveAs(blob,file_name);
+    },
+    saveTextAsFile: function(textToWrite, fileName) {
+        var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
+        var fileNameToSaveAs = fileName;
+
+        var downloadLink = document.createElement("a");
+        downloadLink.download = fileNameToSaveAs;
+        downloadLink.innerHTML = "Download File";
+        if (window.webkitURL != null)
+        {
+            // Chrome allows the link to be clicked
+            // without actually adding it to the DOM.
+            downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
+        }
+        else
+        {
+            // Firefox requires the link to be added to the DOM
+            // before it can be clicked.
+            downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
+            downloadLink.onclick = destroyClickedElement;
+            downloadLink.style.display = "none";
+            document.body.appendChild(downloadLink);
+        }
+        downloadLink.click();
+    },
+    destroyClickedElement: function(event)
+    {
+        document.body.removeChild(event.target);
+    },
+    convertDataArrayToCSVText: function(data_array, requestedFieldHash){
+       
+        var text = '';
+        Ext.each(Object.keys(requestedFieldHash), function(key){
+            text += requestedFieldHash[key] + ',';
+        });
+        text = text.replace(/,$/,'\n');
+        
+        Ext.each(data_array, function(d){
+            Ext.each(Object.keys(requestedFieldHash), function(key){
+                if (d[key]){
+                    if (typeof d[key] === 'object'){
+                        if (d[key].FormattedID) {
+                            text += Ext.String.format("\"{0}\",",d[key].FormattedID ); 
+                        } else if (d[key].Name) {
+                            text += Ext.String.format("\"{0}\",",d[key].Name );                    
+                        } else if (!isNaN(Date.parse(d[key]))){
+                            text += Ext.String.format("\"{0}\",",Rally.util.DateTime.formatWithDefaultDateTime(d[key]));
+                        }else {
+                            text += Ext.String.format("\"{0}\",",d[key].toString());
+                        }
+                    } else {
+                        text += Ext.String.format("\"{0}\",",d[key] );                    
+                    }
+                } else {
+                    text += ',';
+                }
+            },this);
+            text = text.replace(/,$/,'\n');
+        },this);
+        return text;
+    },
+    _getCSVFromWsapiBackedGrid: function(grid) {
+        var deferred = Ext.create('Deft.Deferred');
+        var store = Ext.create('Rally.data.wsapi.Store',{
+            fetch: grid.getStore().config.fetch,
+            filters: grid.getStore().config.filters,
+            model: grid.getStore().config.model,
+            limit:Infinity,
+            pageSize: Infinity
+
+        });
+        
+        var columns = grid.columns;
+        var headers = this._getHeadersFromGrid(grid);
+        var column_names = this._getColumnNamesFromGrid(grid);
+        
+        var record_count = grid.getStore().getTotalCount(),
+            page_size = grid.getStore().pageSize,
+            pages = Math.ceil(record_count/page_size),
+            promises = [];
+
+        for (var page = 1; page <= pages; page ++ ) {
+            promises.push(this.loadStorePage(grid, store, columns, page, pages));
+        }
+        Deft.Promise.all(promises).then({
+            success: function(csvs){
+                var csv = [];
+                csv.push('"' + headers.join('","') + '"');
+                _.each(csvs, function(c){
+                    _.each(c, function(line){
+                        csv.push(line);
+                    });
+                });
+                csv = csv.join('\r\n');
+                deferred.resolve(csv);
+                Rally.getApp().setLoading(false);
+            }
+        });
+        return deferred.promise;
+    },
+
+    // custom grid assumes there store is fully loaded
+    _getCSVFromCustomBackedGridWithPaging: function(grid) {
+        var deferred = Ext.create('Deft.Deferred');
+
+
+        var store = Ext.create('Rally.data.custom.Store',{
+            model: grid.getStore().config.model,
+            filters: grid.getStore().config.filters,
+            limit:Infinity,
+            pageSize: Infinity
+        });
+
+        var columns = grid.columns;
+        var headers = this._getHeadersFromGrid(grid);
+        var column_names = this._getColumnNamesFromGrid(grid);
+        
+        var record_count = grid.getStore().getTotalCount(),
+            page_size = grid.getStore().pageSize,
+            pages = Math.ceil(record_count/page_size),
+            promises = [];
+
+        // for (var page = 1; page <= pages; page ++ ) {
+        //     promises.push(this.loadStorePage(grid, store, columns, page, pages));
+        // }
+
+        promises.push(this.loadStorePage(grid, store, columns, page, pages));
+
+        Deft.Promise.all(promises).then({
+            success: function(csvs){
+                var csv = [];
+                csv.push('"' + headers.join('","') + '"');
+                _.each(csvs, function(c){
+                    _.each(c, function(line){
+                        csv.push(line);
+                    });
+                });
+                csv = csv.join('\r\n');
+                deferred.resolve(csv);
+                Rally.getApp().setLoading(false);
+            }
+        });
+        return deferred.promise;
+
+        // var headers = this._getHeadersFromGrid(grid);
+        
+        // var columns = grid.columns;
+        // var column_names = this._getColumnNamesFromGrid(grid);
+
+       
+        // var csv = [];
+        // csv.push('"' + headers.join('","') + '"');
+
+        // var number_of_records = store.getTotalCount();
+        
+        // this.logger.log("Number of records to export:", number_of_records);
+        
+        // for (var i = 0; i < number_of_records; i++) {
+        //     var record = store.getAt(i);
+        //     if ( ! record ) {
+        //         this.logger.log("Number or lines in CSV:", csv.length);
+        //         return csv.join('\r\n');            }
+        //     csv.push( this._getCSVFromRecord(record, grid, store) );
+        // }
+        
+        // this.logger.log("Number or lines in CSV:", csv.length);
+        // return csv.join('\r\n');
+    },
+
+    
+    // custom grid assumes there store is fully loaded
+    _getCSVFromCustomBackedGrid: function(grid) {
+    var deferred = Ext.create('Deft.Deferred');
+            var me = this;
+            
+            Rally.getApp().setLoading("Assembling data for export...");
+            
+            var headers = this._getHeadersFromGrid(grid);
+            var store = Ext.clone( grid.getStore() );
+            var columns = grid.columns;
+            var column_names = this._getColumnNamesFromGrid(grid);
+            
+            var record_count = grid.getStore().getTotalCount();
+            var original_page_size = grid.getStore().pageSize;
+            
+            var page_size = 20000;
+            var number_of_pages = Math.ceil(record_count/page_size);
+            store.pageSize = page_size;
+            
+            var pages = [],
+                promises = [];
+
+            for (var page = 1; page <= number_of_pages; page ++ ) {
+                pages.push(page);
+            }
+            
+            Ext.Array.each(pages, function(page) {
+                promises.push(function() { 
+                    return me._loadStorePage(grid, store, columns, page, pages.length )
+                });
+            });
+            
+            Deft.Chain.sequence(promises).then({
+                success: function(csvs){
+
+                    // set page back to last view
+                    store.pageSize = original_page_size;
+                    store.loadPage(1);
+                    
+                    var csv = [];
+                    csv.push('"' + headers.join('","') + '"');
+                    _.each(csvs, function(c){
+                        _.each(c, function(line){
+                            csv.push(line);
+                        });
+                    });
+                    csv = csv.join('\r\n');
+                    deferred.resolve(csv);
+                    Rally.getApp().setLoading(false);
+                }
+            });
+            
+            return deferred.promise;
+    },
+    
+
+
+    _loadStorePage: function(grid, store, columns, page, total_pages){
+        var deferred = Ext.create('Deft.Deferred');
+
+        store.loadPage(page, {
+            callback: function (records) {
+                var csv = [];
+                for (var i = 0; i < records.length; i++) {
+                    // if(i==0){
+                    //     Rally.getApp().setLoading("Loading page "+page+ " of "+total_pages);
+                    // }
+                    var record = records[i];
+                    csv.push( this._getCSVFromRecord(record, grid, store) );
+                }
+                deferred.resolve(csv);
+            },
+            scope: this
+        });
+        this.logger.log("_loadStorePage", page, " of ", total_pages);
+        return deferred.promise;
+    },
+
+
+    _getHeadersFromGrid: function(grid) {
+        var headers = [];        
+        var columns = grid.columns;
+
+        Ext.Array.each(columns,function(column){
+            if ( column.dataIndex || column.renderer ) {
+                if ( column.csvText ) {
+                    headers.push(column.csvText.replace('&nbsp;',' '));
+                } else if ( column.text )  {
+                    headers.push(column.text.replace('&nbsp;',' '));
+                }
+            }
+        });
+        
+        return headers;
+    },
+    
+    _getColumnNamesFromGrid: function(grid) {
+        var names = [];
+        var columns = grid.columns;
+
+        Ext.Array.each(columns,function(column){
+            if ( column.dataIndex || column.renderer ) {
+                names.push(column.dataIndex);
+            }
+        });
+        
+        return names;
+    },
+    /*
+     * will render using your grid renderer.  If you want it to ignore the grid renderer, 
+     * have the column set _csvIgnoreRender: true
+     */
+    getCSVFromGrid:function(app, grid){
+        this.logger.log("Exporting grid with store type:", Ext.getClassName(grid.getStore()));
+        
+        if ( Ext.getClassName(grid.getStore()) != "Rally.data.custom.Store" ) {
+            return this._getCSVFromWsapiBackedGrid(grid);
+        }
+        
+        return this._getCSVFromCustomBackedGrid(grid);
+    },
+
+    loadStorePage: function(grid, store, columns, page, total_pages){
+        console.log('Inside loadStorePage');
+        var deferred = Ext.create('Deft.Deferred');
+        this.logger.log('loadStorePage',page, total_pages);
+
+        store.loadPage(page, {
+            callback: function (records, operation, success) {
+                //console.log(' page records length',records.length,'success',success);
+                var csv = [];
+                Rally.getApp().setLoading(Ext.String.format('Page {0} of {1} loaded',page, total_pages));
+                for (var i = 0; i < records.length; i++) {
+                    var record = records[i];
+                    csv.push( this._getCSVFromRecord(record, grid, store) );
+                }
+                deferred.resolve(csv);
+            },
+            scope: this
+        });
+        return deferred;
+    },
+    
+    _getCSVFromRecord: function(record, grid, store) {
+        var mock_meta_data = {
+            align: "right",
+            classes: [],
+            cellIndex: 9,
+            column: null,
+            columnIndex: 9,
+            innerCls: undefined,
+            recordIndex: 5,
+            rowIndex: 5,
+            style: "",
+            tdAttr: "",
+            tdCls: "x-grid-cell x-grid-td x-grid-cell-headerId-gridcolumn-1029 x-grid-cell-last x-unselectable",
+            unselectableAttr: "unselectable='on'"
+        };
+        
+        var node_values = [];
+        var columns = grid.columns;
+        //console.log('inside _getCSVFromRecord');
+        Ext.Array.each(columns, function (column) {
+            if (column.xtype != 'rallyrowactioncolumn') {
+                if (column.dataIndex) {
+                    var column_name = column.dataIndex;
+                    
+                    var display_value = record.get(column_name);
+
+                    if (!column._csvIgnoreRender && column.renderer) {
+                        if (column.exportRenderer) {
+                            display_value = column.exportRenderer(display_value, mock_meta_data, record, 0, 0, store, grid.getView());
+                        } else {
+                            display_value = column.renderer(display_value, mock_meta_data, record, 0, 0, store, grid.getView());
+                        }
+                    }
+                    //node_values.push(display_value ? display_value.replace(/"/g, '""') : display_value);
+                    node_values.push(display_value);
+                } else {
+                    var display_value = null;
+                    if (!column._csvIgnoreRender && column.renderer) {
+                        if (column.exportRenderer) {
+                            display_value = column.exportRenderer(display_value, mock_meta_data, record, record, 0, 0, store, grid.getView());
+                        } else {
+                            display_value = column.renderer(display_value, mock_meta_data, record, record, 0, 0, store, grid.getView());
+                        }
+                        // node_values.push(display_value ? display_value.replace(/"/g, '""') : display_value);
+                        node_values.push(display_value);
+                    }
+                }
+
+            }
+        }, this);
+        console.log('Node values',node_values);
+        return '"' + node_values.join('","') + '"';
+    }
+
+});

--- a/data-hygiene/src/javascript/utils/_ts-project-tree-picker-dialog.js
+++ b/data-hygiene/src/javascript/utils/_ts-project-tree-picker-dialog.js
@@ -1,0 +1,519 @@
+Ext.define('CA.technicalservices.ProjectTreePickerDialog', {
+    extend: 'Rally.ui.dialog.Dialog',
+    alias: 'widget.projecttreepickerdialog',
+
+    minWidth: 400,
+    width: 400,
+    minHeight: 300,
+    height: 300,
+    
+    layout: 'fit',
+    closable: true,
+    draggable: true,
+
+    config: {
+        /**
+         * @cfg {String}
+         * Title to give to the dialog
+         */
+        title: 'Choose Project(s)',
+
+        /**
+         * @cfg {Boolean}
+         * Allow multiple selection or not
+         */
+        multiple: true,
+
+        /**
+         * @cfg {Object}
+         * An {Ext.data.Store} config object used when building the grid
+         * Handy when you need to limit the selection with store filters
+         */
+        storeConfig: {
+            context: {
+                project: null
+            },
+            sorters: [
+                {
+                    property: 'FormattedID',
+                    direction: 'DESC'
+                }
+            ]
+        },
+
+        /**
+         * @cfg {Ext.grid.Column}
+         * List of columns that will be used in the chooser
+         */
+        columns: [
+            'Name'
+        ],
+
+        /**
+         * @cfg {String}
+         * Text to be displayed on the button when selection is complete
+         */
+        selectionButtonText: 'Done',
+
+        /**
+         * @cfg {Object}
+         * The grid configuration to be used when creative the grid of items in the dialog
+         */
+        gridConfig: {},
+
+        /**
+         * @cfg {String}|{String[]}
+         * The ref(s) of items which should be selected when the chooser loads
+         */
+        selectedRecords: undefined,
+
+        /**
+         * @cfg {Array}
+         * The records to select when the chooser loads
+         */
+        initialSelectedRecords: undefined,
+
+        /**
+         * @cfg showRadioButtons {Boolean}
+         */
+        showRadioButtons: true,
+        
+        /**
+         * @cfg showSearchBox {Boolean}
+         * 
+         * [ Experimental.  Search box might not work ]
+         */
+        showSearchBox: false
+    },
+
+    constructor: function(config) {
+        this.mergeConfig(config);
+
+        this.callParent([this.config]);
+    },
+
+    selectionCache: [],
+
+    initComponent: function() {
+        this.callParent(arguments);
+
+        this.addEvents(
+            /**
+             * @event artifactchosen
+             * Fires when user clicks done after choosing an artifact
+             * @param {Rally.ui.dialog.ArtifactChooserDialog} source the dialog
+             * @param {Rally.data.wsapi.Model}| {Rally.data.wsapi.Model[]} selection selected record or an array of selected records if multiple is true
+             */
+            'itemschosen'
+        );
+
+        this.addCls(['chooserDialog', 'chooser-dialog']);
+    },
+
+    destroy: function() {
+        //      this._destroyTooltip();
+        this.callParent(arguments);
+    },
+
+    beforeRender: function() {
+        this.callParent(arguments);
+
+        this.addDocked({
+            xtype: 'toolbar',
+            dock: 'bottom',
+            padding: '0 0 10 0',
+            layout: {
+                type: 'hbox',
+                pack: 'center'
+            },
+            ui: 'footer',
+            items: [
+                {
+                    xtype: 'rallybutton',
+                    itemId: 'doneButton',
+                    text: this.selectionButtonText,
+                    cls: 'primary rly-small',
+                    scope: this,
+                    disabled: true,
+                    userAction: 'clicked done in dialog',
+                    handler: function() {
+                        this.fireEvent('itemschosen', this.getSelectedRecords());
+                        this.close();
+                    }
+                },
+                {
+                    xtype: 'rallybutton',
+                    text: 'Cancel',
+                    cls: 'secondary rly-small',
+                    handler: this.close,
+                    scope: this,
+                    ui: 'link'
+                }
+            ]
+        });
+
+        if (this.introText) {
+            this.addDocked({
+                xtype: 'component',
+                componentCls: 'intro-panel',
+                html: this.introText
+            });
+        }
+
+        if ( this.showSearchBox ) {
+            this.addDocked({
+                xtype: 'toolbar',
+                itemId: 'searchBar',
+                dock: 'top',
+                border: false,
+                padding: '0 0 10px 0',
+                items: this.getSearchBarItems()
+            });
+        }
+
+        this.buildGrid();
+
+        this.selectionCache = this.getInitialSelectedRecords() || [];
+    },
+
+    /**
+     * Get the records currently selected in the dialog
+     * {Rally.data.Model}|{Rally.data.Model[]}
+     */
+    getSelectedRecords: function() {
+        return this.multiple ? this.selectionCache : this.selectionCache[0];
+    },
+
+    getSearchBarItems: function() {
+        
+        return [
+            {
+                xtype: 'triggerfield',
+                cls: 'rui-triggerfield chooser-search-terms',
+                emptyText: 'Search Keyword or ID',
+                enableKeyEvents: true,
+                flex: 1,
+                itemId: 'searchTerms',
+                listeners: {
+                    keyup: function (textField, event) {
+                        if (event.getKey() === Ext.EventObject.ENTER) {
+                            this._search();
+                        }
+                    },
+                    afterrender: function (field) {
+                        field.focus();
+                    },
+                    scope: this
+                },
+                triggerBaseCls: 'icon-search chooser-search-icon'
+            }
+        ];
+    },
+    getStoreFilters: function() {
+        return [];
+    },
+
+    buildGrid: function() {
+        if (this.grid) {
+            this.grid.destroy();
+        }
+        var me = this;
+
+        this.setLoading('Fetching Project Tree...');
+        Ext.create('Rally.data.wsapi.ProjectTreeStoreBuilder').build({
+            models: ['project'],
+            autoLoad: true,
+            enableHierarchy: true,
+            filters: [{
+                property: 'Parent',
+                value: ""
+            }]
+        }).then({
+            scope: this,
+            success: function(store) {
+
+                var mode = this.multiple ? 'MULTI' : 'SINGLE';
+
+                var checkbox_model = Ext.create('Rally.ui.selection.CheckboxModel', {
+                    mode: mode,
+                    enableKeyNav: false,
+                    allowDeselect: true
+                });
+
+                this.grid = this.add({
+                    xtype: 'rallytreegrid',
+                    treeColumnDataIndex: 'Name',
+                    treeColumnHeader: 'Name',
+                    viewConfig: {
+                        cls: 'grid-view-bulk-edit'
+                    },
+                    enableRanking: false,
+                    enableEditing: false,
+                    enableBulkEdit: false,
+                    shouldShowRowActionsColumn: false,
+
+                    selModel: checkbox_model,
+                    _defaultTreeColumnRenderer: function (value, metaData, record, rowIdx, colIdx, store) {
+                        store = store.treeStore || store;
+                        return Rally.ui.renderer.RendererFactory.getRenderTemplate(store.model.getField('Name')).apply(record.data);
+                    },
+                    columnCfgs: [],
+                    store: store
+                });
+
+                this.mon(this.grid, {
+                    beforeselect: this._onGridSelect,
+                    beforedeselect: this._onGridDeselect,
+                    load: this._onGridLoad,
+                    scope: this
+                });
+                this.add(this.grid);
+                this._onGridReady();
+            }
+        }).always(function() { me.setLoading(false);} );
+    },
+
+    _enableDoneButton: function() {
+        this.down('#doneButton').setDisabled(this.selectionCache.length ? false : true);
+    },
+
+    _findRecordInSelectionCache: function(record){
+        return _.findIndex(this.selectionCache, function(cachedRecord) {
+            return cachedRecord.get('_ref') === record.get('_ref');
+        });
+    },
+
+    _onGridSelect: function(selectionModel, record) {
+        var index = this._findRecordInSelectionCache(record);
+
+        if (index === -1) {
+            if (!this.multiple) {
+                this.selectionCache = [];
+            }
+            this.selectionCache.push(record);
+        }
+
+        this._enableDoneButton();
+    },
+
+    _onGridDeselect: function(selectionModel, record) {
+        var index = this._findRecordInSelectionCache(record);
+        if (index !== -1) {
+            this.selectionCache.splice(index, 1);
+        }
+        this._enableDoneButton();
+    },
+
+    _onGridReady: function() {
+        if (!this.grid.rendered) {
+            this.mon(this.grid, 'afterrender', this._onGridReady, this, {single: true});
+            return;
+        }
+
+        if (this.grid.getStore().isLoading()) {
+            this.mon(this.grid, 'load', this._onGridReady, this, {single: true});
+            return;
+        }
+
+        this._onGridLoad();
+        this.center();
+    },
+    _onGridLoad: function() {
+        var store = this.grid.store;
+        var records = [];
+        Ext.Array.each(this.selectionCache, function(record) {
+            var foundNode = store.getRootNode().findChild('_ref', record.get('_ref'),true);
+
+            if (foundNode) {
+                records.push(foundNode);
+            }
+        });
+        if (records.length) {
+            this.grid.getSelectionModel().select(records);
+        }
+    },
+    _search: function() {
+        var terms = this._getSearchTerms();
+        var store = this.grid.getStore();
+        //Filter functions call store load so we don't need to refresh the selections becuaes the
+        //onGridLoad function will
+        if (terms) {
+            store.filter([
+                Ext.create('Rally.data.wsapi.Filter',{
+                    property: 'Name',
+                    operator: 'contains',
+                    value: terms
+                })
+            ]);
+        } else {
+            store.clearFilter();
+        }
+
+    },
+    _getSearchTerms: function() {
+        var textBox = this.down('#searchTerms');
+        return textBox && textBox.getValue();
+    }
+});
+
+Ext.override(Rally.data.wsapi.ParentChildMapper, {
+    constructor: function() {
+        this.parentChildTypeMap = {
+            project: [{
+                typePath: 'project', collectionName: 'Children', parentField: 'Parent'
+            }],
+            hierarchicalrequirement: [
+                {typePath: 'defect', collectionName: 'Defects', parentField: 'Requirement'},
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'WorkProduct'},
+                {typePath: 'hierarchicalrequirement', collectionName: 'Children', parentField: 'Parent'}
+            ],
+            defect: [
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'WorkProduct'}
+            ],
+            defectsuite: [
+                {typePath: 'defect', collectionName: 'Defects', parentField: 'DefectSuites'},
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'WorkProduct'}
+            ],
+            testset: [
+                {typePath: 'task', collectionName: 'Tasks', parentField: 'WorkProduct'},
+                {typePath: 'testcase', collectionName: 'TestCases', parentField: 'TestSets'}
+            ]
+        };
+    }
+});
+
+
+Ext.define('Rally.data.wsapi.ProjectTreeStore', {
+
+    extend: 'Rally.data.wsapi.TreeStore',
+    alias: 'store.rallyprojectwsapitreestore',
+    
+    /**
+     * The type definition typePaths to render as root items (required)
+     * @cfg {String[]} parentTypes
+     */
+    parentTypes: ['project'],
+    
+    /**
+     * @property
+     * @private
+     */
+    childLevelSorters: [{
+        property: 'Name',
+        direction: 'ASC'
+    }],
+        
+    getParentFieldNamesByChildType: function(childType, parentType) {
+        return ['Parent'];
+    },
+
+    _getChildNodeFilters: function(node) {
+        var parentType = node.self.typePath,
+            childTypes = this._getChildTypePaths([parentType]),
+            parentFieldNames = this._getParentFieldNames(childTypes, parentType);
+
+        var filter = [];
+        if (parentFieldNames.length) {
+            filter =  [
+                Rally.data.wsapi.Filter.or(_.map(parentFieldNames, function(parentFieldName) {
+                    return {
+                        property: parentFieldName,
+                        operator: '=',
+                        value: node.get('_ref')
+                    };
+                }))
+            ];
+        }
+
+        return filter;
+    },
+
+    filter: function(filters) {
+        console.log('--');
+        this.fireEvent('beforefilter', this);
+        //We need to clear the filters to remove the Parent filter
+        this.filters.clear();
+        this.filters.addAll(filters);
+        this._resetCurrentPage();
+        this.load();
+    },
+    
+    load: function(options) {
+        this.recordLoadBegin({description: 'tree store load', component: this.requester});
+
+        this._hasErrors = false;
+
+        this.on('beforeload', function(store, operation) {
+            delete operation.id;
+        }, this, { single: true });
+
+        options = this._configureLoad(options);
+        options.originalCallback = options.callback;
+        var deferred = Ext.create('Deft.Deferred'),
+            me = this;
+
+        options.callback = function (records, operation, success) {
+            me.dataLoaded = true;
+
+            if (me._pageIsEmpty(operation)) {
+                me._reloadEmptyPage(options).then({
+                    success: function (records) {
+                        // this gives a maximum callstack exceeded error.  don't know why
+                        //me._resolveLoadingRecords(deferred, records, options, operation, success);
+                    },
+                    failure: function() {
+                        me._rejectLoadingRecord(deferred, options, operation);
+                    }
+                });
+            } else {
+                //me._resolveLoadingRecords(deferred, records, options, operation, success);
+            }
+        };
+
+        if (this._isViewReady()) {
+            this._beforeInitialLoad(options);
+        }
+
+        this.callParent([options]);
+
+        return deferred.promise;
+    },
+
+    clearFilter: function(suppressEvent) {
+        this._resetCurrentPage();
+        this.filters.clear();
+        //We need to add the parent filter back in
+        this.filters.addAll(Ext.create('Rally.data.wsapi.Filter',{
+            property: 'Parent',
+            value: ''
+        }));
+
+        if (!suppressEvent) {
+            this.load();
+        }
+    }
+});
+
+Ext.define('Rally.data.wsapi.ProjectTreeStoreBuilder', {
+    extend: 'Rally.data.wsapi.TreeStoreBuilder',
+
+    build: function(config) {
+        config = _.clone(config || {});
+        config.storeType = 'Rally.data.wsapi.ProjectTreeStore';
+
+        return this.loadModels(config).then({
+            success: function(models) {
+                models = _.values(models);
+                return this._buildStoreWithModels(models, config);
+            },
+            scope: this
+        });
+    },
+
+    _useCompositeArtifacts: function (models, config) {
+        return false;
+    }
+});

--- a/data-hygiene/src/javascript/utils/_ts-project-tree-picker-field.js
+++ b/data-hygiene/src/javascript/utils/_ts-project-tree-picker-field.js
@@ -1,0 +1,214 @@
+Ext.define('CA.technicalservices.ProjectTreePickerSettingsField',{
+    extend: 'Ext.form.field.Base',
+    alias: 'widget.tsprojectsettingsfield',
+    fieldSubTpl: '<div id="{id}" class="settings-grid"></div>',
+    width: '100%',
+    cls: 'column-settings',
+
+    store: undefined,
+    labelAlign: 'top',
+    
+    onDestroy: function() {
+        if (this._grid) {
+            this._grid.destroy();
+            delete this._grid;
+        }
+        this.callParent(arguments);
+    },
+    
+    initComponent: function(){
+
+        this.callParent();
+        this.addEvents('ready');
+
+        this.setLoading('loading...');
+        var store = Ext.create('Rally.data.wsapi.Store', {
+            model: 'Project',
+            fetch: ['Name','ObjectID'],
+            //filters: [{property:'ObjectID', value: -1 }],
+            pageSize: 2000,
+            limit: 'Infinity'
+        });
+        store.load({
+            scope: this,
+            callback: this._buildProjectGrid
+        });
+
+    },
+
+    onRender: function() {
+        this.callParent(arguments);
+        this.setLoading('Loading projects...');
+    },
+        
+    _buildProjectGrid: function(records, operation, success){
+        this.setLoading(false);
+        var container = Ext.create('Ext.container.Container',{
+            layout: { type:'hbox' },
+            renderTo: this.inputEl,
+            minHeight: 50,
+            minWidth: 50
+        });
+        
+        var decodedValue = {};
+        
+        if (this.initialConfig && this.initialConfig.value && !_.isEmpty(this.initialConfig.value)){
+            if (!Ext.isObject(this.initialConfig.value)){
+                decodedValue = Ext.JSON.decode(this.initialConfig.value);
+            } else {
+                decodedValue = this.initialConfig.value;
+            }
+        }
+       
+        var data = [],
+            empty_text = "No selections";
+
+        console.log('initial config', this._value, this.initialConfig, decodedValue);
+            
+        if (success && decodedValue !== {} ) {
+            Ext.Array.each(records, function(project){
+                var setting = decodedValue[project.get('_ref')];
+                if ( setting && setting !== {} ) {
+                    data.push({
+                        _ref: project.get('_ref'), 
+                        projectName: project.get('Name'),
+                        Name: project.get('Name'),
+                        ObjectID: project.get('ObjectID')
+                    });
+                }
+            });
+        } else {
+            empty_text = "Error(s) fetching Project data: <br/>" + operation.error.errors.join('<br/>');
+        }
+
+        var custom_store = Ext.create('Ext.data.Store', {
+            fields: ['_ref', 'projectName','Name', 'ObjectID'],
+            data: data
+        });
+        
+        var gridWidth = Math.min(this.inputEl.getWidth(true)-100, 500);
+        this.inputEl.set
+        this._grid = container.add(  {
+            xtype:'rallygrid',
+            autoWidth: true,
+            columnCfgs: this._getColumnCfgs(),
+            showRowActionsColumn:false,
+            showPagingToolbar: false,
+            store: custom_store,
+            height: 150,
+            width: gridWidth,
+            emptyText: empty_text,
+            editingConfig: {
+                publishMessages: false
+            }
+        });
+
+        var width = Math.min(this.inputEl.getWidth(true)-20, 600);
+        
+        //Ext.create('Rally.ui.Button',{
+        container.add({
+            xtype: 'rallybutton',
+            text: 'Select Programs',
+            margin: '0 0 0 10',
+            listeners: {
+                scope: this,
+                click: function(){
+
+                    Ext.create('CA.technicalservices.ProjectTreePickerDialog',{
+                        autoShow: true,
+                        width: width,
+                        selectedRefs: _.pluck(data, '_ref'),
+                        listeners: {
+                            scope: this,
+                            itemschosen: function(items){
+                                var new_data = [],
+                                    store = this._grid.getStore();
+
+                                Ext.Array.each(items, function(item){
+                                    if (!store.findRecord('_ref',item.get('_ref'))){
+                                        new_data.push({
+                                            _ref: item.get('_ref'),
+                                            projectName: item.get('Name'),
+                                            Name: item.get('Name'),
+                                            ObjectID: item.get('ObjectID')
+                                        });
+                                    }
+                                });
+                                this._grid.getStore().add(new_data);
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+       this.fireEvent('ready', true);
+    },
+    _removeProject: function(){
+        this.grid.getStore().remove(this.record);
+    },
+    _getColumnCfgs: function() {
+        var me = this;
+
+        var columns = [{
+            xtype: 'rallyrowactioncolumn',
+            scope: this,
+            rowActionsFn: function(record){
+                return  [
+                    {text: 'Remove', record: record, handler: me._removeProject, grid: me._grid }
+                ];
+            }
+        },
+        {
+            text: 'Program',
+            dataIndex: '_ref',
+            flex: 1,
+            editor: false,
+            renderer: function(v, m, r){
+                return r.get('projectName');
+            },
+            getSortParam: function(v,m,r){
+                return 'projectName';
+            }
+        }];
+        return columns;
+    },
+    /**
+     * When a form asks for the data this field represents,
+     * give it the name of this field and the ref of the selected project (or an empty string).
+     * Used when persisting the value of this field.
+     * @return {Object}
+     */
+    getSubmitData: function() {
+        var data = {};
+        data[this.name] = Ext.JSON.encode(this._buildSettingValue());
+        return data;
+    },
+    
+    _buildSettingValue: function() {
+        var mappings = {};
+        var store = this._grid.getStore();
+
+        store.each(function(record) {
+            if (record.get('_ref')) {
+                mappings[record.get('_ref')] = {
+                    'Name': record.get('projectName') || "",
+                    'ObjectID': record.get('ObjectID') || "",
+                    '_ref': record.get('_ref') || ""
+                }
+            }
+        }, this);
+        return mappings;
+    },
+
+    getErrors: function() {
+        var errors = [];
+        //Add validation here
+        return errors;
+    },
+    setValue: function(value) {
+        console.log('setValue', value);
+        this.callParent(arguments);
+        this._value = value;
+    }
+});

--- a/data-hygiene/src/javascript/utils/_ts-validator.js
+++ b/data-hygiene/src/javascript/utils/_ts-validator.js
@@ -311,7 +311,7 @@ Ext.define('CA.techservices.validator.Validator',{
                     };
 
                 Ext.Array.each(projectGroups, function(pg){
-                    hash[pg.groupName] = results[idx++];
+                    hash[pg.Name] = results[idx++];
                 });
                 deferred.resolve(hash);
             },


### PR DESCRIPTION
- Add "Project" column to the   pop-up
- Make the pop-up exportable
- Enable selection of any   Portfolio, Program, Track or Team in App Settings (i.e. re-code the app to   provide more flexibility, similar to the Sprint Metrics app). We would like   to be able to select which portfolios, programs, tracks or teams are   reflected in the dashboard)
- UI issues - pop-up for   "Stories with incorrect Release tag (does not match parent   Feature)" does not show“USxxxx” (icon is visible but the US   number is not)
- Delete “Features with CR field   checked” item under “Feature Level Data Hygiene”
- Delete “Feature Sets not “AOP   approved”” item under “Feature Level Data Hygiene”
- Fix wording and validate   calculation for "Features Sets” with incorrect Project field value à should be "Program" or "Sub-Program"
- Fix wording and validate   calculations for "Features” with incorrect Project field value à should be "Program" or "Sub-Program"
- Add new item under "Story   Level Data Hygiene" --> Stories with Project   field value “Track”
- Pop-up for "Stories with   incorrect Release tag (does not match parent Feature", can we add   Feature & Release values for both Feature and Story? à lowest priority